### PR TITLE
Fix typos across the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ A packaged FLM Windows installer is available here: [**flm-setup.exe**](https://
 📺 [**Watch the quick start video**](https://www.youtube.com/watch?v=mYOfDNkyBII)
 
 > [!IMPORTANT]  
-> ⚠️ Ensure NPU driver verison is **>= 32.0.203.304** (`.304` is the minimum requirement but `.311` is recommended; check via Task Manager→Performance→NPU or Device Manager).  
+> ⚠️ Ensure NPU driver version is **>= 32.0.203.304** (`.304` is the minimum requirement but `.311` is recommended; check via Task Manager→Performance→NPU or Device Manager).  
 > ⚙️ **Tip:**
 >   * **RECOMMENDED**: Try running **Windows Update** or **[Driver Download](https://www.amd.com/en/support)**.
 >   * **[Official AMD Install Doc](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers)** *(AMD account required)*.
->   * **[Unofficial forum downloads](https://www.elevenforum.com/t/drivers-amd-npu-ryzen-8xxx-9xxx-apu.24220/)** *(CAUTION, we no do not hold responsible for what you download here)*.
+>   * **[Unofficial forum downloads](https://www.elevenforum.com/t/drivers-amd-npu-ryzen-8xxx-9xxx-apu.24220/)** *(CAUTION, we do not hold responsible for what you download here)*.
 
 After installation, open **PowerShell** (`Win + X → I`). To run a model in terminal (**CLI Mode**):
 ```powershell

--- a/docs/docs/instructions/cli.md
+++ b/docs/docs/instructions/cli.md
@@ -127,7 +127,7 @@ flm port
 
 ---
 
-### ⚡ NPU Power Mode NPU Power Mode
+### ⚡ NPU Power Mode
 
 By default, **FLM runs in `performance` NPU power mode**. You can switch to other NPU power modes (`powersaver`, `balanced`, or `turbo`) using the `--pmode` flag:
 

--- a/docs/docs/instructions/server/msft_AI_toolkit.md
+++ b/docs/docs/instructions/server/msft_AI_toolkit.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: Microsfot AI Toolkit + FLM
+title: Microsoft AI Toolkit + FLM
 nav_order: 4
 parent: Local Server (Server Mode)
 ---

--- a/docs/docs/instructions/server/obsidian.md
+++ b/docs/docs/instructions/server/obsidian.md
@@ -40,13 +40,13 @@ Run the following command in your powershell to launch the FastFlowLM server:
 #### Option A: OpenAI API
 
 1. Click **⚙️** to open the setting panel.
-2. Under **Community Plugins** section (left), clik **AI Providers**.
+2. Under **Community Plugins** section (left), click **AI Providers**.
 3. Click **➕** to create a new provider.
 4. Set **Provider type** to **OpenAI**.
 5. Enter the **Provider URL**: `http://127.0.0.1:52625/v1`.
 6. Enter a **Provider name** (e.g., `FLM_OpenAI`).
 7. Enter any **API key** (e.g., `flm`).
-8. On the **Model** line, click the **🔄** icon to load available models, then select your preferred modle (e.g. llama3.2:1b).
+8. On the **Model** line, click the **🔄** icon to load available models, then select your preferred model (e.g. llama3.2:1b).
 9. Click **Save**.
 
 #### Option B: OpenAI API
@@ -68,7 +68,7 @@ Run the following command in your powershell to launch the FastFlowLM server:
 1. Click **⚙️** to open the setting panel.
 2. Under **Community Plugins** section (left), click **Local GPT**.
 3. Set **Main AI Provider** to the provider you configured earlier (e.g., `FLM_OpenAI ~ llama3.2:1b`).
-4. Review the **Action list** to see what **Loca GPT** can do.
+4. Review the **Action list** to see what **Local GPT** can do.
 
 #### Set up hotkeys
 

--- a/docs/docs/instructions/server/webui.md
+++ b/docs/docs/instructions/server/webui.md
@@ -11,7 +11,7 @@ parent: Local Server (Server Mode)
   - [ Option 1: Use Open WebUI Desktop](#option-1-use-open-webui-desktop)  
   - [ Option 2: Use Open WebUI in Docker](#option-2-use-open-webui-in-docker)  
 - **[🧪 More Examples](#-more-examples)**
-  - [ Example: Multi Models Comparision Enabled by FLM Queuing](#-example-multi-models-comparision-enabled-by-flm-queuing)  
+  - [ Example: Multi Models Comparison Enabled by FLM Queuing](#-example-multi-models-comparison-enabled-by-flm-queuing)  
   - [ Example: Agentic AI Web Search with FastFlowLM](#-example-agentic-ai-web-search-with-fastflowlm)  
   - [ Example: Local Private Database with RAG + FastFlowLM](#️-example-local-private-database-with-rag--fastflowlm)
   
@@ -229,7 +229,7 @@ Well done 🎉 — now let’s explore more apps together!
 
 ---
 
-## 🤖 Example: Multi Models Comparision Enabled by FLM Queuing
+## 🤖 Example: Multi Models Comparison Enabled by FLM Queuing
 
 A step-by-step guide to launching FastFlowLM and interacting with multiple models via Open WebUI.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,7 +145,7 @@ sections:
         No drivers, no guesswork—just run the installer, pull a model, and start chatting.
       items:
         - heading: "Zero-conf installer"
-          body: "igned installers for every Ryzen™ AI 300 laptop — download, run, done."
+          body: "Signed installers for every Ryzen™ AI 300 laptop — download, run, done."
         - heading: "Drop-in APIs"
           body: "OpenAI-compatible APIs — plug in your existing tools instantly."
         - heading: "Secure by default"


### PR DESCRIPTION
This pull request mainly addresses documentation improvements by correcting typos across multiple markdown files.

Documentation corrections and improvements:

* Fixed several spelling errors and typos in `docs/docs/instructions/server/obsidian.md`, such as "clik" to "click", "modle" to "model", and "Loca GPT" to "Local GPT". 
* Corrected "Comparision" to "Comparison" in section headings and links in `docs/docs/instructions/server/webui.md`.
* Updated the text for "Zero-conf installer" in `docs/index.md` from "igned installers" to "Signed installers".
* Fixed the spelling of "Microsfot" to "Microsoft" in the title of `docs/docs/instructions/server/msft_AI_toolkit.md`.
* Improved phrasing and corrected minor errors in the NPU driver requirements and tips in `README.md`.
* Removed a duplicated heading in the NPU Power Mode section of `docs/docs/instructions/cli.md`.