### PR TITLE
feat: non-stream parsing support for reasoning models

### DIFF
--- a/src/common/AutoModel/modeling_lfm2.cpp
+++ b/src/common/AutoModel/modeling_lfm2.cpp
@@ -401,7 +401,7 @@ bool LFM2_5_TK::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input) {
 std::string LFM2_5_TK::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
     os << "<think>\n" << std::flush;
     std::string result = this->_shared_generate(meta_info, length_limit, os, is_cancelled);
-    result += "<think>\n";
+    result = "<think>\n" + result;
     return result;
 }
 
@@ -410,6 +410,28 @@ std::string LFM2_5_TK::generate_with_prompt(chat_meta_info_t& meta_info, lm_unif
         return "";
     }
     return this->generate(meta_info, length_limit, os);
+}
+
+NonStreamResult LFM2_5_TK::parse_nstream_content(const std::string response_text) {
+    NonStreamResult result;
+
+    std::string content, reasoning_content;
+
+    std::string think_start_tag = "<think>";
+    std::string think_end_tag = "</think>";
+
+    size_t think_start_pos = response_text.find(think_start_tag);
+    size_t think_end_pos = response_text.find(think_end_tag);
+
+
+    think_start_pos += think_start_tag.length();
+    std::string reasoning_str = response_text.substr(think_start_pos, think_end_pos - think_start_pos);
+    result.reasoning_content = reasoning_str;
+
+    std::string content_str = response_text.substr(think_end_pos + think_end_tag.length());
+    result.content = content_str;
+
+    return result;
 }
 
 StreamResult LFM2_5_TK::parse_stream_content(const std::string content) {

--- a/src/common/AutoModel/modeling_llama3.cpp
+++ b/src/common/AutoModel/modeling_llama3.cpp
@@ -188,6 +188,28 @@ std::string DeepSeek_r1_8b::generate_with_prompt(chat_meta_info_t& meta_info, lm
     return this->generate(meta_info, length_limit, os);
 }
 
+NonStreamResult DeepSeek_r1_8b::parse_nstream_content(const std::string response_text) {
+    NonStreamResult result;
+
+    std::string content, reasoning_content;
+
+    std::string think_start_tag = "<think>";
+    std::string think_end_tag = "</think>";
+
+    size_t think_start_pos = response_text.find(think_start_tag);
+    size_t think_end_pos = response_text.find(think_end_tag);
+
+
+    think_start_pos += think_start_tag.length();
+    std::string reasoning_str = response_text.substr(think_start_pos, think_end_pos - think_start_pos);
+    result.reasoning_content = reasoning_str;
+
+    std::string content_str = response_text.substr(think_end_pos + think_end_tag.length());
+    result.content = content_str;
+
+    return result;
+}
+
 StreamResult DeepSeek_r1_8b::parse_stream_content(const std::string content) {
     const std::string MARKER_THINK_START = "<think>";
     const std::string MARKER_THINK_END = "</think>";

--- a/src/common/AutoModel/modeling_qwen3.cpp
+++ b/src/common/AutoModel/modeling_qwen3.cpp
@@ -606,6 +606,29 @@ std::string DeepSeek_r1_0528_8b::generate_with_prompt(chat_meta_info_t& meta_inf
     return this->_shared_generate(meta_info, length_limit, os);
 }
 
+NonStreamResult DeepSeek_r1_0528_8b::parse_nstream_content(const std::string response_text) {
+    NonStreamResult result;
+
+    std::string content, reasoning_content;
+
+    std::string think_start_tag = "<think>";
+    std::string think_end_tag = "</think>";
+
+    size_t think_start_pos = response_text.find(think_start_tag);
+    size_t think_end_pos = response_text.find(think_end_tag);
+
+
+    think_start_pos += think_start_tag.length();
+    std::string reasoning_str = response_text.substr(think_start_pos, think_end_pos - think_start_pos);
+    result.reasoning_content = reasoning_str;
+
+    std::string content_str = response_text.substr(think_end_pos + think_end_tag.length());
+    result.content = content_str;
+
+    return result;
+}
+
+
 StreamResult DeepSeek_r1_0528_8b::parse_stream_content(const std::string content) {
     const std::string MARKER_THINK_START = "<think>";
     const std::string MARKER_THINK_END = "</think>";

--- a/src/include/AutoModel/modeling_gpt_oss.hpp
+++ b/src/include/AutoModel/modeling_gpt_oss.hpp
@@ -45,6 +45,7 @@ public:
     std::vector<int> get_function_name_tokens();
     void update_state(int token_id);
     void mask_logits(buffer<bf16>& logits, const std::vector<int>& allowed_tokens);
+    NonStreamResult parse_nstream_content(const std::string response_text);
     StreamResult parse_stream_content(const std::string content);
 
     /// \brief Override configure_parameter to handle GPT-oss-specific parameters

--- a/src/include/AutoModel/modeling_lfm2.hpp
+++ b/src/include/AutoModel/modeling_lfm2.hpp
@@ -58,5 +58,6 @@ public:
     std::string generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled = [] { return false; }) override;
     std::string generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os = std::cout) override;
     std::string apply_chat_template(nlohmann::ordered_json& messages, nlohmann::ordered_json tools = nlohmann::ordered_json::object()) override;
+    NonStreamResult parse_nstream_content(const std::string response_text);
     StreamResult parse_stream_content(const std::string content);
 };

--- a/src/include/AutoModel/modeling_llama3.hpp
+++ b/src/include/AutoModel/modeling_llama3.hpp
@@ -40,5 +40,6 @@ public:
     std::string generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled = [] { return false; }) override;
     std::string generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os = std::cout) override;
     std::string apply_chat_template(nlohmann::ordered_json& messages, nlohmann::ordered_json tools = nlohmann::ordered_json::object()) override;
+    NonStreamResult parse_nstream_content(const std::string response_text);
     StreamResult parse_stream_content(const std::string content);
 };

--- a/src/include/AutoModel/modeling_qwen3.hpp
+++ b/src/include/AutoModel/modeling_qwen3.hpp
@@ -116,5 +116,6 @@ public:
     std::string generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled = [] { return false; }) override;
     std::string generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os = std::cout) override;
     std::string apply_chat_template(nlohmann::ordered_json& messages, nlohmann::ordered_json tools = nlohmann::ordered_json::object()) override;
+    NonStreamResult parse_nstream_content(const std::string response_text);
     StreamResult parse_stream_content(const std::string content);
 };


### PR DESCRIPTION
1. feat: non-stream parsing support for reasoning models
2. fix: `LFM2.5-tk` error location of `<think>` in non-stream mode