### PR TITLE
fix: parse error for qwen3vl-it and qwen3-it in non-stream mode

### DIFF
--- a/src/common/AutoModel/modeling_qwen3.cpp
+++ b/src/common/AutoModel/modeling_qwen3.cpp
@@ -266,10 +266,10 @@ NonStreamResult Qwen3_IT::parse_nstream_content(const std::string response_text)
     size_t start_pos = response_text.find(start_tag);
     size_t end_pos = response_text.find(end_tag);
 
-    // Safety check: if tags are not found
     if (start_pos == std::string::npos || end_pos == std::string::npos) {
-        // error
-        return { name, arguments };
+        // pure content
+        result.content = response_text;
+        return result;
     }
 
     start_pos += start_tag.length();

--- a/src/common/AutoModel/modeling_qwen3vl.cpp
+++ b/src/common/AutoModel/modeling_qwen3vl.cpp
@@ -205,10 +205,10 @@ NonStreamResult Qwen3VL::parse_nstream_content(const std::string response_text) 
     size_t start_pos = response_text.find(start_tag);
     size_t end_pos = response_text.find(end_tag);
 
-    // Safety check: if tags are not found
     if (start_pos == std::string::npos || end_pos == std::string::npos) {
-        // error
-        return { name, arguments };
+        // pure content
+        result.content = response_text;
+        return result;
     }
 
     start_pos += start_tag.length();


### PR DESCRIPTION
Fixes a parse error that caused empty normal‑content responses  in qwen3-it and qwen3vl-it when running in non‑stream mode.