### PR TITLE
Return appropriate HTTP error codes

### DIFF
--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -836,7 +836,13 @@ void RestHandler::handle_openai_chat_completion(const json& request,
             header_print("FLM", "Start prefill...");
             bool success = auto_chat_engine->insert(meta_info, uniformed_input);
             if (!success) {
-                json error_response = { {"error", "Max length reached"} };
+                json error_response = {
+                    {"error", {
+                        {"message", "Max length reached!"},
+                        {"type", "model_error"},
+                        {"code", 400}
+                    }}
+                };
                 send_response(error_response);
                 return;
             }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -664,7 +664,22 @@ bool WebServer::handle_request(http::request<http::string_body>& req,
 
         // catch is_deferred 
         auto send_response = [&res, session, this, request_id, needs_npu, is_deferred](const json& response_data) {
-            res.result(http::status::ok);
+            http::status status = http::status::ok;
+
+            if (response_data.contains("error") &&
+                response_data["error"].contains("code"))
+            {
+                int code = response_data["error"]["code"].get<int>();
+
+                if (code == 400) {
+                    status = http::status::bad_request;
+                }
+                //else if () {
+
+                //}
+            }
+
+            res.result(status);
             res.body() = response_data.dump();
             res.set(http::field::content_type, "application/json");
             res.prepare_payload();


### PR DESCRIPTION
Returns an appropriate `400` HTTP error code when the prompt is up to the max length in the server mode.