### PR TITLE
Use ~amd-team/xrt PPA for building containers

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         include:
           - ubuntu_version: "24.04"
-            ubuntu_ppa: "ppa:superm1/xrt"
+            ubuntu_ppa: "ppa:amd-team/xrt"
           - ubuntu_version: "25.10"
-            ubuntu_ppa: "ppa:superm1/xrt"
+            ubuntu_ppa: "ppa:amd-team/xrt"
           - ubuntu_version: "26.04"
             ubuntu_ppa: ""
 


### PR DESCRIPTION
These can be more "official" backports.

We can potentially publish a DKMS package to these containers for amdxdna as well for older Ubuntu releases.