### PR TITLE
InnoSetup: Set ChangesEnvironment=yes

### DIFF
--- a/src/inno/flm.iss
+++ b/src/inno/flm.iss
@@ -24,6 +24,8 @@ SolidCompression=yes
 
 LicenseFile=terms.txt
 
+ChangesEnvironment=yes
+
 ; Icon configuration to preserve original background
 SetupIconFile=logo.ico
 


### PR DESCRIPTION
The FastFlowLM modifies some environment variables but  doesn't send the [WM_SETTINGCHANGE](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-settingchange) message which means that the currently running `explorer.exe` process does not notice the environment has changed; so when you run a `cmd.exe` or a Powershell window (e.g. from start menu etc.), you also only get the old environment without `FLM_MODEL_PATH`. Logging out and back in, or restarting explorer helps, or to just modify any other env variable in the GUI to trigger the message. This also [causes issues](https://github.com/lemonade-sdk/lemonade/issues/797) with Lemonade.

I'd like to suggest setting [`ChangesEnvironment=yes`](https://jrsoftware.org/ishelp/index.php?topic=setup_changesenvironment) in the InnoSetup script which will make the setup send the message which will fix this issue.