### PR TITLE
Update Linux minimum kernel check to be more accurate

### DIFF
--- a/src/include/npu_utils/npu_utils.hpp
+++ b/src/include/npu_utils/npu_utils.hpp
@@ -588,7 +588,7 @@ public:
             return;
         }
 
-        amdxdna_drm_query_aie_metadata query_aie_metadata;
+        amdxdna_drm_query_aie_metadata query_aie_metadata = {};
         get_info.param = DRM_AMDXDNA_QUERY_AIE_METADATA;
         get_info.buffer_size = sizeof(amdxdna_drm_query_aie_metadata);
         get_info.buffer = (unsigned long)&query_aie_metadata;

--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -13,6 +13,7 @@
 #include "utils/utils.hpp"
 #include "program_args.hpp"
 #include "minja/chat-template.hpp"
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -299,12 +300,16 @@ static bool sanity_check_npu_stack(bool quiet, bool json_output = false) {
 
         struct drm_version drm_v;
         memset(&drm_v, 0, sizeof(drm_v));
+        std::string drm_version_str = "unknown";
         if (ioctl(fd, DRM_IOCTL_VERSION, &drm_v) == 0) {
+            drm_version_str = std::to_string(drm_v.version_major) + "." + std::to_string(drm_v.version_minor);
             if (!(drm_v.version_major > 0 || (drm_v.version_major == 0 && drm_v.version_minor >= 6))) {
                 drm_version_ok = false;
             }
+        } else {
+            drm_version_ok = false;
         }
-        validation_json["drm_version"] = std::to_string(drm_v.version_major) + "." + std::to_string(drm_v.version_minor);
+        validation_json["drm_version"] = drm_version_str;
 
         amdxdna_drm_query_firmware_version query_fw_version;
         amdxdna_drm_get_info get_info = {


### PR DESCRIPTION
The standard DRM IOCTL `DRM_IOCTL_VERSION` can discover the
driver major and minor. The minor version at kernel 6.19 added pre-emption.
Try to detect this as a minimum version.

Link: https://github.com/torvalds/linux/commit/3a0ff7b98af4a5de1b995dfb57e65843f9b7b628

It's not strictly true because other fixes from kernel 7.0 were also
needed, but this helps to rule out anything older than 6.19 as being
directly supported.

