### PR TITLE
fix: attempt to raise memlock limit to infinity before failing validation

### DIFF
--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -609,6 +609,30 @@ int main(int argc, char* argv[]) {
         parsed_args.model_tag = "model-faker"; // Use default tag
     }
 
+#ifndef _WIN32
+    // Raise memlock limit to accommodate the model being loaded
+    if ((parsed_args.command == "run" || parsed_args.command == "serve" || parsed_args.command == "bench") &&
+        parsed_args.model_tag != "model-faker" && !parsed_args.model_tag.empty()) {
+        auto [resolved_tag, model_info] = availble_models.get_model_info(parsed_args.model_tag);
+        if (model_info.contains("size")) {
+            rlim_t model_size = model_info["size"].get<uint64_t>();
+            // Add 512MB overhead for working memory beyond the model itself
+            rlim_t required = model_size + (512ULL * 1024 * 1024);
+            struct rlimit rl;
+            if (getrlimit(RLIMIT_MEMLOCK, &rl) == 0) {
+                if (rl.rlim_cur != RLIM_INFINITY && rl.rlim_cur < required) {
+                    struct rlimit rl_new = { required, required };
+                    if (setrlimit(RLIMIT_MEMLOCK, &rl_new) == 0) {
+                        header_print_g("Linux", "Memlock Limit: raised to " << (required / 1024 / 1024) << " MB for " << resolved_tag);
+                    } else {
+                        header_print("Linux", "Warning: could not raise memlock limit to " << (required / 1024 / 1024) << " MB");
+                    }
+                }
+            }
+        }
+    }
+#endif
+
     // code for all commands:
     
     if (parsed_args.command == "version") {


### PR DESCRIPTION
When the memlock limit is below 100MB, try setrlimit(RLIMIT_MEMLOCK)
to raise it to RLIM_INFINITY automatically. Only report an error and
fail validation if setrlimit itself fails (e.g. insufficient privileges).