### PR TITLE
fix: Added build preset for linux that's more flexible for building into a snap package

### DIFF
--- a/src/CMakePresets.json
+++ b/src/CMakePresets.json
@@ -23,6 +23,17 @@
       }
     },
     {
+      "name": "linux-snap",
+      "displayName": "Linux Snap Build",
+      "description": "Configuration for building inside a snapcraft part",
+      "inherits": "common-default",
+      "generator": "Ninja",
+      "binaryDir": "$env{CRAFT_PART_BUILD}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
       "name": "windows-default",
       "displayName": "Windows Default",
       "description": "Default configuration for Windows using Visual Studio",


### PR DESCRIPTION
When bundled in a snap we do need to specify some paths that are at odds with the linux-default preset, but would like to benefit from what's provided by the common presets.