### PR TITLE
feat: use XDG cache directory for models on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ flm run llama3.2:1b
 > - Sometimes downloads from HuggingFace may get corrupted. If this happens, run `flm pull <model_tag> --force` (e.g. `flm pull llama3.2:1b --force`) to re-download and fix them.
 > - By default, models are stored in:
 >   - **Windows**: `C:\Users\<USER>\Documents\flm\models\`
->   - **Linux**: `~/.config/flm/`
+>   - **Linux**: `~/.cache/flm/` (follows XDG Base Directory spec; customize with `XDG_CACHE_HOME`)
+> - If you have existing models in `~/.config/flm/models`, FastFlowLM will continue to use that location (with a deprecation warning).
 > - During installation on Windows, you can select a different base folder (e.g., if you choose `C:\Users\<USER>\flm`, models will be saved under `C:\Users\<USER>\flm\models\`).
 > - On Linux, you can override the default location by setting the `FLM_MODEL_PATH` environment variable.
 > - ⚠️ If HuggingFace is not accessible in your region, manually download the model ([check this issue](https://github.com/FastFlowLM/FastFlowLM/issues/2)) and place it in the chosen directory.   

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -140,6 +140,30 @@ std::string get_user_documents_directory() {
 #endif
 }
 
+std::string get_cache_directory() {
+#ifdef _WIN32
+    char* local_app_data = nullptr;
+    size_t len = 0;
+    if (_dupenv_s(&local_app_data, &len, "LOCALAPPDATA") == 0 && local_app_data != nullptr) {
+        std::string result(local_app_data);
+        free(local_app_data);
+        return result;
+    }
+    return ".";
+#else
+    const char* xdg_cache = std::getenv("XDG_CACHE_HOME");
+    if (xdg_cache && *xdg_cache) {
+        return std::string(xdg_cache);
+    }
+
+    const char* home = std::getenv("HOME");
+    if (home && *home) {
+        return std::string(home) + "/.cache";
+    }
+    return ".";
+#endif
+}
+
 int get_server_port(int user_port) {
     if (user_port > 0 && user_port <= 65535) {
         return user_port;
@@ -197,12 +221,22 @@ std::string get_models_directory() {
         return std::string(model_path_env);
     }
 #endif
-    // Fallback to Documents/flm/models on Windows or ~/.config/flm on Linux if environment variable is not set
+    // Fallback to Documents/flm/models on Windows or ~/.cache/flm on Linux if environment variable is not set
     std::string documents_dir = get_user_documents_directory();
+    std::string cache_dir = get_cache_directory();
 #ifdef _WIN32
     return documents_dir + "/flm/models";
 #else
-    return documents_dir + "/flm";
+    // Check for deprecated location ~/.config/flm/models and warn user
+    std::string deprecated_path = documents_dir + "/flm/models";
+    if (std::filesystem::exists(deprecated_path)) {
+        std::cerr << "[FLM] WARNING: Found models in deprecated location: " << deprecated_path << std::endl;
+        std::cerr << "[FLM] Please move your models to: " << cache_dir << "/flm/models" << std::endl;
+        std::cerr << "[FLM] Alternatively, set FLM_MODEL_PATH environment variable to specify a custom location." << std::endl;
+        std::cerr << "[FLM] The deprecated location may be removed in future versions." << std::endl;
+        return deprecated_path;
+    }
+    return cache_dir + "/flm";
 #endif
 }
 

--- a/src/include/utils/utils.hpp
+++ b/src/include/utils/utils.hpp
@@ -345,6 +345,10 @@ inline bool check_file_exists(std::string name) {
 /// \return the user's Documents directory path on Windows, ~/.config on Linux
 std::string get_user_documents_directory();
 
+/// \brief get the user's cache directory on Windows or ~/.cache on Linux
+/// \return the user's cache directory path on Windows, ~/.cache on Linux
+std::string get_cache_directory();
+
 ///@brief get_executable_directory gets the directory where the executable is located
 ///@return the executable directory path
 std::string get_executable_directory();
@@ -376,7 +380,7 @@ std::string find_xclbin_path();
 ///@return the server port, default is 52625 if environment variable is not set
 int get_server_port(int user_port);
 
-///@brief get_models_directory gets the models directory from environment variable or defaults to Documents/flm/models on Windows or ~/.config/flm on Linux
+///@brief get_models_directory gets the models directory from environment variable or defaults to Documents/flm/models on Windows or ~/.cache/flm on Linux
 ///@return the models directory path
 std::string get_models_directory();
 

--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -150,7 +150,7 @@ std::string get_user_documents_directory() {
 ///@brief ensure_models_directory creates the models directory if it doesn't exist
 ///@param exe_dir the executable directory
 void ensure_models_directory(const std::string& exe_dir) {
-    // Use Documents/flm/models directory on Windows or ~/.config/flm on Linux for models instead of executable directory
+    // Use Documents/flm/models directory on Windows or ~/.cache/flm on Linux for models instead of executable directory
     std::string models_dir = utils::get_models_directory();
     if (!std::filesystem::exists(models_dir)) {
         std::filesystem::create_directories(models_dir);
@@ -215,34 +215,6 @@ int get_server_port(int user_port) {
     }
 
     return 52625; // Default port
-}
-
-///@brief get_models_directory gets the models directory from environment variable or defaults to Documents/flm/models on Windows or ~/.config/flm on Linux
-///@return the models directory path
-std::string get_models_directory() {
-#ifdef _WIN32
-    char* model_path_env = nullptr;
-    size_t len = 0;
-    if (_dupenv_s(&model_path_env, &len, "FLM_MODEL_PATH") == 0 && model_path_env != nullptr) {
-        std::string custom_path(model_path_env);
-        free(model_path_env);
-        if (!custom_path.empty()) {
-            return custom_path;
-        }
-    }
-#else
-    const char* model_path_env = std::getenv("FLM_MODEL_PATH");
-    if (model_path_env && *model_path_env) {
-        return std::string(model_path_env);
-    }
-#endif
-    // Fallback to Documents/flm/models on Windows or ~/.config/flm on Linux if environment variable is not set
-    std::string documents_dir = get_user_documents_directory();
-#ifdef _WIN32
-    return documents_dir + "/flm/models";
-#else
-    return documents_dir + "/flm";
-#endif
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
Changed the default models directory from ~/.config/flm to ~/.cache/flm on Linux to follow the XDG Base Directory specification. The old location is still supported with a deprecation warning for backward compatibility.

- Added get_cache_directory() utility function
- Updated get_models_directory() to use cache dir by default
- Removed duplicate get_models_directory() from main.cpp
- Updated README with new default path and XDG info
- FLM_MODEL_PATH env var still overrides the default