### PR TITLE
Add a build container for Debian 13

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -14,12 +14,19 @@ jobs:
           - release: "24.04"
             ubuntu_ppa: "ppa:amd-team/xrt"
             distro: "ubuntu"
+            backports: ""
           - release: "25.10"
             ubuntu_ppa: "ppa:amd-team/xrt"
             distro: "ubuntu"
+            backports: ""
           - release: "26.04"
             ubuntu_ppa: ""
             distro: "ubuntu"
+            backports: ""
+          - release: "13"
+            distro: "debian"
+            ubuntu_ppa: ""
+            backports: "trixie-backports"
 
     permissions:
       contents: read
@@ -57,6 +64,7 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ matrix.distro }}:${{ matrix.release }}
             UBUNTU_PPA=${{ matrix.ubuntu_ppa }}
+            BACKPORTS=${{ matrix.backports }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,23 @@ LABEL org.opencontainers.image.source="https://github.com/FastFlowLM/FastFlowLM"
 # Prevent interactive prompts during installation
 ENV DEBIAN_FRONTEND=noninteractive
 ARG UBUNTU_PPA=""
+ARG BACKPORTS=""
+
+# Set up PPA if needed
+RUN if [ -n "$UBUNTU_PPA" ]; then \
+        apt update && apt install -y software-properties-common && \
+        add-apt-repository -y "$UBUNTU_PPA"; \
+    fi
+
+# setup backports if needed
+RUN if [ -n "$BACKPORTS" ]; then \
+        echo "deb http://deb.debian.org/debian $BACKPORTS main" >> /etc/apt/sources.list; \
+        apt update; \
+        apt install -t $BACKPORTS -y libxrt-dev; \
+    fi
 
 # Install all build dependencies
 RUN apt update && apt install -y \
-    software-properties-common \
-    && if [ -n "$UBUNTU_PPA" ]; then add-apt-repository -y "$UBUNTU_PPA"; fi \
-    && apt update && apt install -y \
     build-essential \
     cargo \
     cmake \


### PR DESCRIPTION
This will generate a container with a [backported libxrt](https://packages.debian.org/source/stable-backports/xrt) so that artifacts for Debian 13 can be installed.

After the containre is built I'll send another PR to create the artifact.