### PR TITLE
Generate an artifact for Debian 13

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -18,24 +18,20 @@ jobs:
       matrix:
         include:
           - version: "24.04"
-            container_tag: "ubuntu24.04"
             codename: "noble"
             distro: "ubuntu"
           - version: "25.10"
-            container_tag: "ubuntu25.10"
             codename: "questing"
             distro: "ubuntu"
           - version: "26.04"
-            container_tag: "ubuntu26.04"
             codename: "resolute"
             distro: "ubuntu"
           - version: "13"
-            container_tag: "debiantrixie"
             codename: "trixie"
             distro: "debian"
 
     container:
-      image: ghcr.io/fastflowlm/fastflowlm/build-environment:${{ matrix.container_tag }}
+      image: ghcr.io/fastflowlm/fastflowlm/build-environment:${{ matrix.distro }}${{ matrix.version }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This artifact can be used on Debian 13 as long as trixie-backports is enabled.

Documentation about backports is available here: https://backports.debian.org/