### PR TITLE
Improve linux build install

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -322,9 +322,9 @@ if(WIN32)
     )
 else()
     file(GLOB so_libs "${CMAKE_SOURCE_DIR}/lib/*.so")
-    install(FILES ${so_libs} DESTINATION lib)
+    install(FILES ${so_libs} DESTINATION "${CMAKE_INSTALL_LIBDIR}/flm")
     set_target_properties(flm PROPERTIES
-        INSTALL_RPATH "$ORIGIN/../lib")
+        INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/flm")
 endif()
 install(TARGETS flm
     RUNTIME DESTINATION bin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,8 @@ if(CMAKE_CXX_STANDARD LESS 17)
 endif()
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/../third_party/tokenizers-cpp
-                 ${CMAKE_BINARY_DIR}/tokenizers-cpp)
+                 ${CMAKE_BINARY_DIR}/tokenizers-cpp
+                 EXCLUDE_FROM_ALL)
 
 # ———————————————————————————————————————————————
 # Gather your sources
@@ -321,6 +322,10 @@ if(WIN32)
         DEPENDS flm
     )
 else()
+    if(NOT CMAKE_INSTALL_LIBDIR)
+        set(CMAKE_INSTALL_LIBDIR "lib")
+    endif()
+
     file(GLOB so_libs "${CMAKE_SOURCE_DIR}/lib/*.so")
     install(FILES ${so_libs} DESTINATION "${CMAKE_INSTALL_LIBDIR}/flm")
     set_target_properties(flm PROPERTIES


### PR DESCRIPTION
Do not install files of cmake submodules. `msgpack` for example ha some global INSTALL rules to install headers and data.

Install flm model libs into it's own subir under `libdir` no need for them to be in default LD_LIBRARY_PATH
