### PR TITLE
fix: Properly parse multiedit arguments from qwen3_5

### DIFF
--- a/src/common/AutoModel/modeling_qwen3_5vl.cpp
+++ b/src/common/AutoModel/modeling_qwen3_5vl.cpp
@@ -326,7 +326,12 @@ StreamResult Qwen3_5VL::parse_stream_content(const std::string content) {
                 std::string param_value = block.substr(val_start, val_end - val_start);
                 if (!param_value.empty() && param_value.back() == '\n') param_value.pop_back();
 
-                args[param_name] = param_value;
+                try {
+                    args[param_name] = nlohmann::json::parse(param_value);
+                }
+                catch(const nlohmann::json::parse_error&) {
+                    args[param_name] = param_value;
+                }
                 search_pos = val_end + param_close.length();
             }
 


### PR DESCRIPTION
When using continuedev cli agent usage of the multiedit tool always failed with a json error. Not sure if this is a problem of flm or the conitnue dev tool.
The formating of the resulting `arguments` string looked very wired with escaping of `"` or `\`  and it could be fixed with the change in this MR.