### PR TITLE
Add env switch to disable version update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ flm run llama3.2:1b
 >   - **Linux**: `~/.config/flm/`
 > - During installation on Windows, you can select a different base folder (e.g., if you choose `C:\Users\<USER>\flm`, models will be saved under `C:\Users\<USER>\flm\models\`).
 > - On Linux, you can override the default location by setting the `FLM_MODEL_PATH` environment variable.
+> - To disable the startup version check, set `FLM_DISABLE_UPDATE_CHECK=1`.
 > - ⚠️ If HuggingFace is not accessible in your region, manually download the model ([check this issue](https://github.com/FastFlowLM/FastFlowLM/issues/2)) and place it in the chosen directory.   
 
 🎉🚀 FastFlowLM (FLM) is ready — your NPU is unlocked and you can start chatting with models right away!
@@ -190,4 +191,3 @@ More details on the exact procedure, with dependencies to be installed, for linu
         ```bash
         cmake --install build
         ```
-

--- a/src/include/update.hpp
+++ b/src/include/update.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <cctype>
 #include <algorithm>
+#include <cstdlib>
 
 #include "utils/utils.hpp"
 
@@ -56,6 +57,17 @@ static int compare_semver(std::string a, std::string b) {
 }
 
 static bool g_vercheck_warned_timeout = false;
+
+static bool version_check_disabled() {
+    const char* env = std::getenv("FLM_DISABLE_UPDATE_CHECK");
+    if (!env) return false;
+
+    std::string value(env);
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value == "1" || value == "true" || value == "yes" || value == "on";
+}
 
 #ifdef _WIN32
 
@@ -202,6 +214,8 @@ static std::optional<std::string> http_get_latest_tag_from_github(bool& timed_ou
 
 
 static void check_and_notify_new_version() {
+    if (version_check_disabled()) return;
+
     bool timed_out = false;
     auto latest_opt = http_get_latest_tag_from_github(timed_out);
 
@@ -274,6 +288,8 @@ static std::optional<std::string> http_get_latest_tag_from_github(bool& timed_ou
 }
 
 static void check_and_notify_new_version() {
+    if (version_check_disabled()) return;
+
     bool timed_out = false;
     auto latest_opt = http_get_latest_tag_from_github(timed_out);
 
@@ -292,4 +308,3 @@ static void check_and_notify_new_version() {
     }
 }
 #endif
-


### PR DESCRIPTION
Give users and automated environments a way to opt out of the startup network version check to avoid unwanted network calls, timeouts, or noisy output.