### PR TITLE
Enable --quiet logging suppression for serve mode

### DIFF
--- a/src/include/utils/debug_utils.hpp
+++ b/src/include/utils/debug_utils.hpp
@@ -9,6 +9,21 @@
 #include <iomanip>
 #include <string>
 
+namespace debug_utils {
+inline bool& quiet_mode() {
+    static bool enabled = false;
+    return enabled;
+}
+
+inline void set_quiet_mode(bool enabled) {
+    quiet_mode() = enabled;
+}
+
+inline bool is_quiet_mode() {
+    return quiet_mode();
+}
+} // namespace debug_utils
+
 #ifndef VERBOSE
 #define VERBOSE 0
 #endif
@@ -109,9 +124,11 @@
 /// \param msg the message to log
 #define header_print(header, msg) \
     do { \
-        std::ostringstream oss; \
-        oss << msg; \
-        std::cout << '[' << header << "]  " << oss.str() << std::endl; \
+        if (!debug_utils::is_quiet_mode()) { \
+            std::ostringstream oss; \
+            oss << msg; \
+            std::cout << '[' << header << "]  " << oss.str() << std::endl; \
+        } \
     } while (0)
 
 /// \brief header_print_r macro, in red color
@@ -119,9 +136,11 @@
 /// \param msg the message to log
 #define header_print_r(header, msg) \
     do { \
-        std::ostringstream oss; \
-        oss << msg; \
-        std::cerr << "\033[31m[" << header << "]  " << oss.str() << "\033[0m" << std::endl; \
+        if (!debug_utils::is_quiet_mode()) { \
+            std::ostringstream oss; \
+            oss << msg; \
+            std::cerr << "\033[31m[" << header << "]  " << oss.str() << "\033[0m" << std::endl; \
+        } \
     } while (0)
 
     
@@ -130,9 +149,11 @@
 /// \param msg the message to log
 #define header_print_g(header, msg) \
     do { \
-        std::ostringstream oss; \
-        oss << msg; \
-        std::cout << "\033[32m[" << header << "]  " << oss.str() << "\033[0m" << std::endl; \
+        if (!debug_utils::is_quiet_mode()) { \
+            std::ostringstream oss; \
+            oss << msg; \
+            std::cout << "\033[32m[" << header << "]  " << oss.str() << "\033[0m" << std::endl; \
+        } \
     } while (0)
 
 /// \brief box_print macro

--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -11,6 +11,7 @@
 #include "model_downloader.hpp"
 #include "update.hpp"
 #include "utils/utils.hpp"
+#include "utils/debug_utils.hpp"
 #include "program_args.hpp"
 #include "minja/chat-template.hpp"
 #include <cstring>
@@ -471,6 +472,10 @@ int main(int argc, char* argv[]) {
     program_args_t parsed_args;
     if (!arg_utils::parse_options(argc, argv, parsed_args)) {
         return 1; // Help was already printed by Boost Program Options
+    }
+
+    if (parsed_args.command == "serve" && parsed_args.sub_process_mode) {
+        debug_utils::set_quiet_mode(true);
     }
 
     


### PR DESCRIPTION
I expected `--quiet` mode to work for `flm serve`. This adds support for it.