### PR TITLE
Show model download sizes in flm list

### DIFF
--- a/src/include/program_args.hpp
+++ b/src/include/program_args.hpp
@@ -29,6 +29,7 @@ struct program_args_t {
 
     // for list command
     std::string list_filter = "all";
+    bool list_sizes = false;
 
     // for pull command
     bool force_redownload = false;

--- a/src/include/utils/vm_args.hpp
+++ b/src/include/utils/vm_args.hpp
@@ -51,6 +51,7 @@ inline void print_help(po::options_description& general) {
     std::cout << "\tflm list" << std::endl;
     std::cout << "\tflm list --quiet" << std::endl;
     std::cout << "\tflm list --filter installed" << std::endl;
+    std::cout << "\tflm list --sizes" << std::endl;
     std::cout << std::endl;
 }
 
@@ -73,14 +74,16 @@ bool parse_options(int argc, char *argv[], program_args_t& parsed_args) {
              "If load asr model")
             ("embed,e", po::value<bool>(&parsed_args.embed)->default_value(0),
             "If load embed model")
-            ("host", po::value<std::string>(&parsed_args.host)->default_value("127.0.0.1"), 
+            ("host", po::value<std::string>(&parsed_args.host)->default_value("127.0.0.1"),
              "Set the server address (for serve command)")
-            ("port,p", po::value<int>(&parsed_args.port)->default_value(-1), 
+            ("port,p", po::value<int>(&parsed_args.port)->default_value(-1),
              "Set the server port number (for serve command)")
             ("force", po::bool_switch(&parsed_args.force_redownload),
              "Force re-download even if model exists (for pull command)")
             ("filter", po::value<std::string>(&parsed_args.list_filter)->default_value("all"),
              "Show models: all | installed | not-installed")
+            ("sizes", po::bool_switch(&parsed_args.list_sizes),
+             "Show total and missing download sizes when listing models")
             ("quiet", po::bool_switch(&parsed_args.sub_process_mode),
              "Quiet mode, for sub-process usages")
             ("json,j", po::bool_switch(&parsed_args.json_output),
@@ -201,7 +204,7 @@ bool parse_options(int argc, char *argv[], program_args_t& parsed_args) {
         // Note: serve command allows empty model_tag (will use default)
 
         // Validate power mode for run/serve commands
-        if ((parsed_args.command == "run" || parsed_args.command == "serve") && 
+        if ((parsed_args.command == "run" || parsed_args.command == "serve") &&
             !parsed_args.power_mode.empty()) {
             const std::vector<std::string> valid_modes = {"default", "powersaver", "balanced", "performance", "turbo"};
             if (std::find(valid_modes.begin(), valid_modes.end(), parsed_args.power_mode) == valid_modes.end()) {

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -13,8 +13,56 @@
 /// \brief Constructor
 /// \param models the model list
 /// \return the model downloader
-ModelDownloader::ModelDownloader(model_list& models) 
+ModelDownloader::ModelDownloader(model_list& models)
     : supported_models(models), curl_init() {
+}
+
+/// \brief Get total and missing download size information for a model
+/// \param model_tag the model tag
+/// \return model download size information
+ModelDownloadSize ModelDownloader::get_download_size_info(const std::string& model_tag) {
+    ModelDownloadSize info;
+
+    try {
+        auto [new_model_tag, model_info] = supported_models.get_model_info(model_tag);
+
+        std::string file_url = model_info["file_url"];
+        std::string model_path = supported_models.get_model_path(new_model_tag);
+        std::vector<std::string> model_files = model_info["files"];
+
+        std::string hf_response = download_utils::download_string(file_url);
+        nlohmann::json hf_model_infos = nlohmann::json::parse(hf_response);
+
+        for (const auto& filename : model_files) {
+            auto it = std::find_if(
+                hf_model_infos.begin(),
+                hf_model_infos.end(),
+                [&](const nlohmann::json& f) {
+                    return f.contains("path") && f["path"] == filename;
+                }
+            );
+
+            if (it == hf_model_infos.end() || !it->contains("size")) {
+                continue;
+            }
+
+            double file_size_mb = static_cast<double>((*it)["size"]) / 1024.0 / 1024.0;
+            info.total_mb += file_size_mb;
+            info.total_files++;
+
+            std::string local_path = get_model_file_path(model_path, filename);
+            if (!file_exists(local_path)) {
+                info.missing_mb += file_size_mb;
+                info.missing_files++;
+            }
+        }
+
+        info.exact = true;
+    } catch (const std::exception&) {
+        info.exact = false;
+    }
+
+    return info;
 }
 
 /// \brief Check if the model is downloaded

--- a/src/pull/model_downloader.hpp
+++ b/src/pull/model_downloader.hpp
@@ -15,6 +15,14 @@
 #include <string>
 #include <iostream>
 
+struct ModelDownloadSize {
+    double total_mb = 0.0;
+    double missing_mb = 0.0;
+    size_t total_files = 0;
+    size_t missing_files = 0;
+    bool exact = false;
+};
+
 class ModelDownloader {
 public:
     ModelDownloader(model_list& models);
@@ -25,6 +33,9 @@ public:
     // Download model files if not present
     bool pull_model(const std::string& model_tag, bool force_redownload = false);
     
+    // Get total and missing download size information
+    ModelDownloadSize get_download_size_info(const std::string& model_tag);
+
     // Get list of missing files for a model
     std::vector<std::string> get_missing_files(const std::string& model_tag);
     

--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -34,6 +34,7 @@
 #include "utils/vm_args.hpp"
 #include <boost/program_options.hpp>
 #include "benchmarking.hpp"
+#include <iomanip>
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -507,7 +508,7 @@ int main(int argc, char* argv[]) {
   
     if (parsed_args.command == "serve" || parsed_args.command == "run" || parsed_args.command == "bench"){
         // Configure AMD XRT for the specified power mode
-        if (parsed_args.power_mode == "default" || parsed_args.power_mode == "powersaver" || parsed_args.power_mode == "balanced" || 
+        if (parsed_args.power_mode == "default" || parsed_args.power_mode == "powersaver" || parsed_args.power_mode == "balanced" ||
             parsed_args.power_mode == "performance" || parsed_args.power_mode == "turbo") {
 #ifdef _WIN32
             std::string xrt_cmd = "cd \"C:\\Windows\\System32\\AMD\" && .\\xrt-smi.exe configure --pmode " + parsed_args.power_mode + " > NUL 2>&1";
@@ -680,6 +681,14 @@ int main(int argc, char* argv[]) {
                     if ((parsed_args.list_filter == "installed") == is_present || parsed_args.list_filter == "all") {
                         nlohmann::json model_entry = model;
                         model_entry["installed"] = is_present ? true : false;
+                        if (parsed_args.list_sizes) {
+                            auto size_info = downloader.get_download_size_info(model["name"].get<std::string>());
+                            model_entry["download_total_size_mb"] = size_info.total_mb;
+                            model_entry["download_missing_size_mb"] = size_info.missing_mb;
+                            model_entry["download_total_files"] = size_info.total_files;
+                            model_entry["download_missing_files"] = size_info.missing_files;
+                            model_entry["download_size_exact"] = size_info.exact;
+                        }
                         output_json["models"].push_back(model_entry);
                     }
                 }
@@ -695,6 +704,21 @@ int main(int argc, char* argv[]) {
                         std::cout << "  - " << model["name"].get<std::string>();
                         if (!parsed_args.sub_process_mode) {
                             std::cout << (is_present ? " ✅" : " ⏬");
+                        }
+                        if (parsed_args.list_sizes) {
+                            auto size_info = downloader.get_download_size_info(model["name"].get<std::string>());
+                            if (size_info.exact) {
+                                std::cout << "  total: "
+                                          << std::fixed << std::setprecision(2)
+                                          << size_info.total_mb / 1024.0 << " GB";
+                                if (!is_present) {
+                                    std::cout << "  dl: "
+                                              << std::fixed << std::setprecision(2)
+                                              << size_info.missing_mb / 1024.0 << " GB";
+                                }
+                            } else {
+                                std::cout << "  size: unknown";
+                            }
                         }
                         std::cout << std::endl;
                         any_model_listed = true;


### PR DESCRIPTION
Adds an optional `--sizes` flag for `flm list`.

Examples:

```bash
flm list --sizes
flm list --filter installed --sizes
flm list --filter not-installed --sizes
flm list --json --sizes
```

Example output:

```text
Models:
  - deepseek-r1:8b ⏬  total: 5.36 GB  dl: 5.36 GB
  - llama3.2:1b ✅  total: 1.22 GB
```

The new output shows total model file size and missing download size using Hugging Face model tree metadata.

Behavior:
- Plain `flm list` output remains unchanged.
- Plain `flm list --json` output remains unchanged.
- Size lookup is only done when `--sizes` is passed.
- Invalid filters still return exit code 1.

JSON output with `--sizes` adds:
- `download_total_size_mb`
- `download_missing_size_mb`
- `download_total_files`
- `download_missing_files`
- `download_size_exact`

Tested locally:
- `flm list`
- `flm list --sizes`
- `flm list --filter installed --sizes`
- `flm list --filter not-installed --sizes`
- `flm list --json --sizes`
- `flm list --json`
- `flm list --filter nope --sizes`
