### PR TITLE
Fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -342,9 +342,9 @@ install(DIRECTORY xclbins DESTINATION share/flm)
 if(NOT WIN32 AND NOT CMAKE_INSTALL_PREFIX STREQUAL "/usr" AND NOT CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
     install(CODE "
         message(STATUS \"Creating symlink for flm\")
-        file(MAKE_DIRECTORY \"$ENV{DESTDIR}/usr/local/bin\")
+        file(MAKE_DIRECTORY \"\$ENV{DESTDIR}/usr/local/bin\")
         execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
             \"${CMAKE_INSTALL_PREFIX}/bin/flm\"
-            \"$ENV{DESTDIR}/usr/local/bin/flm\")"
+            \"\$ENV{DESTDIR}/usr/local/bin/flm\")"
     )
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,8 @@ if(CMAKE_CXX_STANDARD LESS 17)
 endif()
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/../third_party/tokenizers-cpp
-                 ${CMAKE_BINARY_DIR}/tokenizers-cpp)
+                 ${CMAKE_BINARY_DIR}/tokenizers-cpp
+                 EXCLUDE_FROM_ALL)
 
 # ———————————————————————————————————————————————
 # Gather your sources

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,7 @@ if(NOT WIN32)
     find_library(READLINE_LIBRARY readline)
     find_library(READLINE_TINFO_LIBRARY tinfo)
     find_library(READLINE_NCURSES_LIBRARY ncurses)
+    find_library(ONIG_LIBRARY onig)
 endif()
 
 # ———————————————————————————————————————————————
@@ -276,6 +277,12 @@ else()
         elseif(READLINE_NCURSES_LIBRARY)
             target_link_libraries(flm PUBLIC ${READLINE_NCURSES_LIBRARY})
         endif()
+    endif()
+
+    if(ONIG_LIBRARY)
+        target_link_libraries(flm PUBLIC ${ONIG_LIBRARY})
+    else()
+        target_link_libraries(flm PUBLIC onig)
     endif()
 
     # Link with dl library for dlopen() support (used for preloading bundled libraries)


### PR DESCRIPTION
This PR contains small CMake build/install fixes.

- defer DESTDIR expansion inside install(CODE) so `cmake --install` does not create `/usr/local/bin/flm` on the host when DESTDIR was empty at configure time
- link flm against Oniguruma explicitly so tokenizer regex symbols resolve reliably

The commits are intentionally kept separate.