### PR TITLE
fix: include closing brace in tool call arguments substring extraction

### DIFF
--- a/src/common/AutoModel/modeling_nanbeige.cpp
+++ b/src/common/AutoModel/modeling_nanbeige.cpp
@@ -295,7 +295,7 @@ NonStreamResult Nanbeige::parse_nstream_content(const std::string response_text)
             size_t brace_end = json_str.rfind("}"); // Find the last closing brace
 
             if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-                arguments = json_str.substr(brace_start, brace_end - brace_start);
+                arguments = json_str.substr(brace_start, brace_end - brace_start + 1);
             }
         }
 

--- a/src/common/AutoModel/modeling_qwen2.cpp
+++ b/src/common/AutoModel/modeling_qwen2.cpp
@@ -133,7 +133,7 @@ NonStreamResult Qwen2::parse_nstream_content(const std::string response_text) {
         size_t brace_end = json_str.rfind("}"); // Find the last closing brace
 
         if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-            arguments = json_str.substr(brace_start, brace_end - brace_start);
+            arguments = json_str.substr(brace_start, brace_end - brace_start + 1);
         }
     }
 

--- a/src/common/AutoModel/modeling_qwen3.cpp
+++ b/src/common/AutoModel/modeling_qwen3.cpp
@@ -148,7 +148,7 @@ NonStreamResult Qwen3::parse_nstream_content(const std::string response_text) {
             size_t brace_end = json_str.rfind("}"); // Find the last closing brace
 
             if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-                arguments = json_str.substr(brace_start, brace_end - brace_start);
+                arguments = json_str.substr(brace_start, brace_end - brace_start + 1);
             }
         }
 
@@ -293,7 +293,7 @@ NonStreamResult Qwen3_IT::parse_nstream_content(const std::string response_text)
         size_t brace_end = json_str.rfind("}"); // Find the last closing brace
 
         if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-            arguments = json_str.substr(brace_start, brace_end - brace_start);
+            arguments = json_str.substr(brace_start, brace_end - brace_start + 1);
         }
     }
 
@@ -497,7 +497,7 @@ NonStreamResult Qwen3_TK::parse_nstream_content(const std::string response_text)
             size_t brace_end = json_str.rfind("}"); // Find the last closing brace
 
             if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-                arguments = json_str.substr(brace_start, brace_end - brace_start);
+                arguments = json_str.substr(brace_start, brace_end - brace_start + 1);
             }
         }
 

--- a/src/common/AutoModel/modeling_qwen3_5vl.cpp
+++ b/src/common/AutoModel/modeling_qwen3_5vl.cpp
@@ -255,7 +255,7 @@ NonStreamResult Qwen3_5VL::parse_nstream_content(const std::string response_text
         size_t brace_end = json_str.rfind("}"); // Find the last closing brace
 
         if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-            arguments = json_str.substr(brace_start, brace_end - brace_start);
+            arguments = json_str.substr(brace_start, brace_end - brace_start + 1);
         }
     }
 

--- a/src/common/AutoModel/modeling_qwen3vl.cpp
+++ b/src/common/AutoModel/modeling_qwen3vl.cpp
@@ -245,7 +245,7 @@ NonStreamResult Qwen3VL::parse_nstream_content(const std::string response_text) 
         size_t brace_end = json_str.rfind("}"); // Find the last closing brace
 
         if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-            arguments = json_str.substr(brace_start, brace_end - brace_start);
+            arguments = json_str.substr(brace_start, brace_end - brace_start + 1);
         }
     }
 


### PR DESCRIPTION
## Bug

`std::string::substr(pos, count)` takes length as the second argument, not end position. The current extraction in 7 places drops the closing brace:

```cpp
size_t brace_start = json_str.find("{", args_pos);
size_t brace_end = json_str.rfind("}");
if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
    arguments = json_str.substr(brace_start, brace_end - brace_start);
}
```

For input `"arguments": {"limit": 6}` where `brace_start=13` and `brace_end=23`, this returns 10 characters starting at index 13, which gives `{"limit": 6` instead of `{"limit": 6}`. The closing brace at position 23 is excluded.

## Fix

Add `+ 1` to the length argument so the closing brace is included.

## Affected files

7 occurrences across 5 model parsers:

- `src/common/AutoModel/modeling_qwen2.cpp:136`
- `src/common/AutoModel/modeling_qwen3.cpp:151`
- `src/common/AutoModel/modeling_qwen3.cpp:296`
- `src/common/AutoModel/modeling_qwen3.cpp:500`
- `src/common/AutoModel/modeling_qwen3vl.cpp:248`
- `src/common/AutoModel/modeling_qwen3_5vl.cpp:258`
- `src/common/AutoModel/modeling_nanbeige.cpp:298`

## Verification

C++ standard says `substr(pos, count)` returns a substring of length up to `count` starting at position `pos`. Last character is at `pos + count - 1`, so the original code excludes the character at `brace_end`. After the fix, last character is at `brace_end`, which is the closing brace.

The streaming parsers (`parse_stream_content`) use `nlohmann::json::parse` and were not affected by this bug. Only the non-streaming substring path was missing the closing brace.

## Possible related issue

This may explain part of #483 (tool call arguments serialization). When the closing brace is missing, downstream JSON parsers either fail or attempt error recovery, which could plausibly produce the int-as-string behaviour reported there. Recommend testing against #483's reproduction after this fix lands.