### PR TITLE
fix: prevent segfault on OPTIONS preflight requests

### DIFF
--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -254,7 +254,8 @@ void HttpSession::handle_request(bool cors) {
         header_print("✈️ ", "Handling Preflight (OPTIONS) request");
 
         // reponse empty body for OPTIONS
-        auto options_res = std::make_shared<http::response<http::empty_body>>();
+        auto options_res = std::make_shared<http::response<http::string_body>>();
+        options_res->body() = "";
         options_res->version(req_.version());
         options_res->result(http::status::ok); 
         options_res->keep_alive(req_.keep_alive());

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -11,7 +11,6 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
-#include <boost/beast/http/empty_body.hpp>
 #include <boost/asio.hpp>
 #include <nlohmann/json.hpp>
 #include <string>


### PR DESCRIPTION
## Summary
- Fixes a SIGSEGV crash in `boost::beast::buffers_suffix::consume()` when handling CORS preflight (OPTIONS) requests
- Changed `http::response<http::empty_body>` to `http::response<http::string_body>` with an empty body, which correctly sets `Content-Length: 0` instead of falling back to chunked transfer encoding

Closes #379

**Tested on:** Linux 7.0.0-14-generic (Ubuntu), AMD Ryzen AI 9 HX 370 w/ Radeon 890M