### PR TITLE
fix: ensure prompt cache is invalidated whenever KV cache is cleared

### DIFF
--- a/src/include/prompt_cache.hpp
+++ b/src/include/prompt_cache.hpp
@@ -109,11 +109,11 @@ public:
                 bool has_tool_call = msg.contains("tool_calls");
                 bool skip_this_message = (role == "tool") || has_tool_call;
                 if (template_type == chat_template_type_t::harmony) {
-                    skip_this_message = false; 
+                    skip_this_message = false;
                 }
 
                 if (skip_this_message) continue;
-                    
+
                 if(i < messages.size() - 2)
                     check_sum_to_compare = _calculate_checksum(content.data(), content.size(), check_sum_to_compare);
                 new_checksum = _calculate_checksum(content.data(), content.size(), new_checksum);
@@ -138,15 +138,16 @@ public:
         uint64_t new_checksum = 0;
         for (size_t i = 0; i < messages.size(); ++i) {
             const auto& msg = messages[i];
+            const std::string role = msg.value("role", "");
             const std::string content = msg.value("content", "");
+            bool has_tool_call = msg.contains("tool_calls");
+            bool skip_this_message = (role == "tool") || has_tool_call;
+            if (skip_this_message) continue;
             new_checksum = _calculate_checksum(content.data(), content.size(), new_checksum);
         }
         checksum_ = new_checksum;
     }
 
-    /// @brief Reset the checksum to force cache miss
-    /// @note This function increments the checksum value by 1 to ensure that
-    ///       the next call to can_use_cache will result in a cache miss.
     void reset() {
         checksum_ = checksum_ + 1;
     }

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -308,6 +308,12 @@ void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
 #endif
 }
 
+///@brief Clear KV cache and invalidate prompt cache
+void RestHandler::reset_context() {
+    auto_chat_engine->clear_context();
+    prompt_cache.reset();
+}
+
 ///@brief Configure chat engine parameters from options and request
 ///@param options the options JSON object
 ///@param request the request JSON object
@@ -475,13 +481,13 @@ void RestHandler::handle_generate(const json& request,
                 if (!success){
                     json error_response = {{"error", "Max length reached"}};
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             try {
@@ -489,7 +495,7 @@ void RestHandler::handle_generate(const json& request,
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             auto total_end_time = time_utils::now();
@@ -508,13 +514,13 @@ void RestHandler::handle_generate(const json& request,
                 if (!success){
                     json error_response = {{"error", "Max length reached"}};
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             try {
@@ -522,7 +528,7 @@ void RestHandler::handle_generate(const json& request,
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             std::string response_text = ss.str();
@@ -591,13 +597,13 @@ void RestHandler::handle_chat(const json& request,
                 if (!success){
                     json error_response = {{"error", "Max length reached"}};
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             try {
@@ -605,22 +611,22 @@ void RestHandler::handle_chat(const json& request,
                 if (!success){
                     json error_response = {{"error", "Max length reached"}};
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             auto total_end_time = time_utils::now();
             meta_info.total_duration = (uint64_t)time_utils::duration_ns(total_start_time, total_end_time).first;
-            
+
             ostream.finalize_chat(meta_info);
             // auto history = this->chat_engine->get_history();
             // std::cout << "history: " << history.first << std::endl;
-            this->auto_chat_engine->clear_context();
+            this->reset_context();
         } else {
             // Non-streaming response
             uniformed_input.messages = messages;
@@ -633,7 +639,7 @@ void RestHandler::handle_chat(const json& request,
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             //std::string response_text = chat_engine->generate_with_prompt(meta_info, prompts, length_limit, std::cout, payload);
@@ -660,7 +666,7 @@ void RestHandler::handle_chat(const json& request,
             
             // auto history = this->chat_engine->get_history();
             // std::cout << "history: " << history.first << std::endl;
-            this->auto_chat_engine->clear_context();
+            this->reset_context();
         }
     } catch (const std::exception& e) {
         json error_response = {{"error", e.what()}};
@@ -974,8 +980,7 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                         meta_info.stop_reason = CANCEL_DETECTED;
                         header_print("❌ ", "Prefill Cancelled!");
                         ostream.finalize(meta_info);
-                        this->auto_chat_engine->clear_context();
-                        this->prompt_cache.reset();
+                        this->reset_context();
                         return;
                     }
 
@@ -987,13 +992,13 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                         }}
                     };
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             header_print("FLM", "Start generating...");
@@ -1002,7 +1007,7 @@ void RestHandler::handle_openai_chat_completion(const json& request,
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             if (meta_info.stop_reason == CANCEL_DETECTED) {
@@ -1013,7 +1018,6 @@ void RestHandler::handle_openai_chat_completion(const json& request,
             ostream.finalize(meta_info);
         }
         else {
-            this->auto_chat_engine->clear_context();
             nullstream nstream;
             json response;
             std::string response_text;
@@ -1025,8 +1029,7 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                         meta_info.stop_reason = CANCEL_DETECTED;
                         header_print("❌ ", "Prefill Cancelled!");
                         send_response(response);
-                        this->auto_chat_engine->clear_context();
-                        this->prompt_cache.reset();
+                        this->reset_context();
                         return;
                     }
                     json error_response = {
@@ -1037,13 +1040,13 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                         }}
                     };
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             header_print("FLM", "Start generating...");
@@ -1052,7 +1055,7 @@ void RestHandler::handle_openai_chat_completion(const json& request,
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             // check response_text
@@ -1080,7 +1083,6 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                 header_print("❌ ", "Generation Cancelled!");
             }
             send_response(response);
-            this->prompt_cache.reset();
         }
 
     } catch (const std::exception& e) {
@@ -1207,13 +1209,13 @@ void RestHandler::handle_openai_completion(const json& request,
                 if (!success) {
                     json error_response = { {"error", "Max length reached"} };
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             try {
@@ -1221,12 +1223,12 @@ void RestHandler::handle_openai_completion(const json& request,
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             ostream.finalize(meta_info);
 
-            this->auto_chat_engine->clear_context();
+            this->reset_context();
         }
         else {
             std::stringstream ss;
@@ -1238,13 +1240,13 @@ void RestHandler::handle_openai_completion(const json& request,
                 if (!success) {
                     json error_response = { {"error", "Max length reached"} };
                     send_response(error_response);
-                    this->auto_chat_engine->clear_context();
+                    this->reset_context();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             try {
@@ -1252,7 +1254,7 @@ void RestHandler::handle_openai_completion(const json& request,
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
-                this->auto_chat_engine->clear_context();
+                this->reset_context();
                 return;
             }
             std::string response_text = ss.str();

--- a/src/server/rest_handler.hpp
+++ b/src/server/rest_handler.hpp
@@ -111,6 +111,7 @@ private:
     bool ensure_model_loaded(const std::string& model_tag);
     void ensure_asr_model_loaded(const std::string& model_tag);
     void ensure_embed_model_loaded(const std::string& model_tag);
+    void reset_context();
     void configure_chat_engine_parameters(const json& options, const json& request);
     json build_nstream_response(std::string response_text);
 


### PR DESCRIPTION
## Summary

Fixes #486

The prompt prefix cache in `/v1/chat/completions` was broken in multiple ways, preventing multi-turn conversations from reusing the cached KV state.

- **Non-streaming path** unconditionally called `clear_context()` and `prompt_cache.reset()`, making prefix caching impossible for non-streaming requests
- **Checksum mismatch** — `update_checksum()` included tool messages while `can_use_cache()` skipped them, causing permanent cache misses when tools were present
- **Stale cache hits after errors** — error paths cleared the KV cache but didn't invalidate the prompt cache, so the next request would only insert the last message into an empty context
- **Stale cache hits from other handlers** — `/api/chat`, `/api/generate`, `/v1/completions` all clear the KV cache without invalidating the prompt cache

## Changes

- Remove unconditional `clear_context()` and `prompt_cache.reset()` from the non-streaming path in `handle_openai_chat_completion`
- Fix `update_checksum()` to skip tool messages consistently with `can_use_cache()`
- Introduce `reset_context()` helper on `RestHandler` that couples `clear_context()` with `prompt_cache.reset()`
- Replace all bare `clear_context()` calls across all handlers with `reset_context()`, except the two cache-miss paths where the cache is immediately re-initialized

## Test plan

- [x] Start `flm serve` with a model
- [x] Send a multi-turn conversation via `/v1/chat/completions` and verify "Use cached prompt!" appears in logs for subsequent turns
- [ ] Verify prefill chunk count drops on cache hits (only the new message is prefilled)
- [ ] Test with tools present in the conversation
- [ ] Test both streaming and non-streaming requests
- [ ] Test that interleaved requests to `/api/chat` or `/api/generate` don't cause stale cache hits on the next `/v1/chat/completions` request