### PR TITLE
Prompt cache 

### DIFF
--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -18,7 +18,6 @@ AutoModel::AutoModel(xrt::device* npu_device_inst, std::string current_model) {
     }
     this->last_prefill_time = { 0, "us" };
     this->token_history.reserve(MAX_L);
-    this->is_first_prompt = true;
 }
 
 
@@ -147,6 +146,33 @@ void AutoModel::_shared_load_model(std::string model_path, json model_info, int 
 
 bool AutoModel::_shared_insert(chat_meta_info_t& meta_info, std::vector<int>& tokens, std::function<bool()> is_cancelled, void* payload, int first_len_run) {
 
+    // print token history
+    // header_print("DEBUG", "Current token history: ");
+    // for (size_t i = 0; i < this->token_history.size(); i++) {
+    //     std::cout << this->token_history[i] << " ";
+    // }
+    // std::cout << std::endl;
+    // // print tokens to insert
+    // header_print("DEBUG", "Tokens to insert: ");
+    // for (size_t i = 0; i < tokens.size(); i++) {
+    //     std::cout << tokens[i] <<  " ";
+    // }
+    // std::cout << std::endl;
+
+    // prefix check for tokens and token history to see if we can skip some tokens
+    const size_t idx = this->token_history.size();
+    size_t skip_count = 0;
+    for (size_t i = 0; i < idx; i++) {
+        if (tokens[i] == this->token_history[i]) {
+            skip_count++;
+        } 
+        else {
+            break;
+        }
+    }
+    tokens.erase(tokens.begin(), tokens.begin() + skip_count);
+
+
     if (this->total_tokens + tokens.size() >= this->MAX_L){
         header_print("WARNING", "Max length reached, stopping prefilling...");
         return false;
@@ -162,13 +188,13 @@ bool AutoModel::_shared_insert(chat_meta_info_t& meta_info, std::vector<int>& to
 
     auto prefill_end_time = this->profiler_list[PREFILL_TIME].stop(tokens.size());
     meta_info.prefill_duration = (uint64_t)time_utils::duration_ns(prefill_start_time, prefill_end_time).first;
-    meta_info.prompt_tokens = tokens.size() + 1;
+    meta_info.prompt_tokens = tokens.size();
 
     if (meta_info.stop_reason == CANCEL_DETECTED) {
         return false;
     }
 
-    this->total_tokens += tokens.size() + 1;
+    this->total_tokens += tokens.size();
     if (this->total_tokens >= this->MAX_L){
         header_print("WARNING", "Max length reached, stopping prefilling...");
     }
@@ -291,7 +317,8 @@ std::string AutoModel::_shared_generate(chat_meta_info_t& meta_info, int length_
     if (this->total_tokens >= this->MAX_L){
         header_print("WARNING", "Max length reached, stopping generation...");
     }
-    header_print("FLM", "Model RAW Output: " + result);
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
     return result;
 }
 
@@ -432,7 +459,6 @@ void AutoModel::clear_context() {
         this->profiler_list[i].reset();
     }
     this->last_prefill_time = { 0, "us" };
-    this->is_first_prompt = true;
 }
 
 

--- a/src/common/AutoModel/modeling_gemma3.cpp
+++ b/src/common/AutoModel/modeling_gemma3.cpp
@@ -61,6 +61,7 @@ bool Gemma3::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std:
     }
     if (!input.messages.empty()) { // already a formated messages, usually from REST API
         templated_text = this->apply_chat_template(input.messages);
+        std::cout << "Templated text after applying chat template: \n" << templated_text << std::endl; // Debug print
     }
     else if (!input.prompt.empty()) { // a pure text, usually from the cli
         nlohmann::ordered_json messages;
@@ -111,6 +112,7 @@ bool Gemma3::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std:
         if (input.images.size() > 0){
             pixel_values.resize(3 * 896 * 896 * sizeof(bf16) * input.images.size());
             uint8_t* pixel_values_ptr = pixel_values.data();
+            uint8_t* pixel_values_base = pixel_values.data();
             auto start_time = std::chrono::high_resolution_clock::now();
             for (auto& image : input.images){
                 bytes image_rgb = load_image(image);
@@ -129,6 +131,21 @@ bool Gemma3::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std:
                 memcpy(pixel_values_ptr, pv.data(), pv.size() * sizeof(bf16));
                 pixel_values_ptr += pv.size() * sizeof(bf16);
             }
+            // Shrink pixel_values to what was actually written so that any
+            // failed image loads do not leave uninitialized trailing data
+            // (which would misalign pixels vs. image tokens during prefill).
+            // `bytes::resize` reallocates without preserving content, so copy
+            // into a fresh buffer instead.
+            const size_t written = static_cast<size_t>(pixel_values_ptr - pixel_values_base);
+            if (written < pixel_values.size()) {
+                if (written == 0) {
+                    pixel_values = bytes();
+                } else {
+                    bytes trimmed(written);
+                    memcpy(trimmed.data(), pixel_values.data(), written);
+                    pixel_values = std::move(trimmed);
+                }
+            }
             auto end_time = std::chrono::high_resolution_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
             header_print("FLM", "Image loaded in " << duration.count() << "ms");
@@ -137,23 +154,95 @@ bool Gemma3::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std:
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
 
     // To avoid redownloading the model, a temporary fix, shall be removed in the next big update on gemma
-    if (tokens[tokens.size() - 1] != 107){
-        tokens.push_back(107);
-    }
-
-    // some models are very sensitive to this bos token, such as lfm2
-    if (this->is_first_prompt == false) {
-        tokens.erase(tokens.begin()); // remove bos token in multi round conversation
-    }
-    this->is_first_prompt = false; // always set to false if the insert is ever called
+    // if (tokens[tokens.size() - 1] != 107){
+    //     tokens.push_back(107);
+    // }
     
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
+
+    // ----------------------------------------------------------------------
+    // Prompt-cache aware image alignment.
+    //
+    // AutoModel::_shared_insert performs a prefix match against token_history
+    // and erases the matched prefix from `tokens` before prefilling. For a
+    // pure-text model that is fine, but for Gemma3 the caller has also packed
+    // `pixel_values` with the images for the WHOLE prompt (including images
+    // from earlier turns that are already in the KV cache) and has computed
+    // `last_image_token_index` from the un-skipped token list.
+    //
+    // If we leave the skip up to _shared_insert, the image embeddings end up
+    // misaligned with the remaining (post-skip) image tokens: pixel data for
+    // already-cached images is fed again, but the corresponding placeholder
+    // tokens have just been erased. Compute the prefix-skip here so we can
+    // drop the matching leading images from `pixel_values` and recompute
+    // `last_image_token_index` against the trimmed token vector.
+    // ----------------------------------------------------------------------
+    const size_t hist_size = this->token_history.size();
+    const size_t cmp_n = std::min(hist_size, tokens.size());
+    size_t skip_count = 0;
+    for (size_t i = 0; i < cmp_n; i++) {
+        if (tokens[i] == this->token_history[i]) {
+            skip_count++;
+        } else {
+            break;
+        }
+    }
+
+    // Total images currently held in pixel_values (each image occupies a
+    // fixed 3*896*896 bf16 elements block).
+    const size_t per_img_bytes = static_cast<size_t>(3) * 896 * 896 * sizeof(bf16);
+    const size_t total_images_in_payload =
+        per_img_bytes > 0 ? pixel_values.size() / per_img_bytes : 0;
+
+    if (skip_count > 0 && total_images_in_payload > 0) {
+        int skipped_image_tokens = 0;
+        for (size_t i = 0; i < skip_count; i++) {
+            if (tokens[i] == IMAGE_TOKEN_ID) skipped_image_tokens++;
+        }
+        int total_image_tokens = 0;
+        for (int t : tokens) {
+            if (t == IMAGE_TOKEN_ID) total_image_tokens++;
+        }
+        if (skipped_image_tokens > 0 && total_image_tokens > 0) {
+            const int per_img_tokens =
+                total_image_tokens / static_cast<int>(total_images_in_payload);
+            if (per_img_tokens > 0) {
+                const size_t skipped_imgs =
+                    static_cast<size_t>(skipped_image_tokens / per_img_tokens);
+                const size_t drop_bytes =
+                    std::min(skipped_imgs * per_img_bytes, pixel_values.size());
+                if (drop_bytes > 0) {
+                    const size_t remaining = pixel_values.size() - drop_bytes;
+                    if (remaining == 0) {
+                        pixel_values = bytes();
+                    } else {
+                        bytes trimmed(remaining);
+                        memcpy(trimmed.data(),
+                               pixel_values.data() + drop_bytes,
+                               remaining);
+                        pixel_values = std::move(trimmed);
+                    }
+                    header_print("FLM",
+                        "Prompt-cache hit: dropped " << skipped_imgs
+                        << " cached image(s) from payload");
+                }
+            }
+        }
+    }
+
+    // Apply the prefix skip to the tokens themselves so that _shared_insert's
+    // own prefix check becomes a no-op (token_history still holds the prefix
+    // and the trimmed tokens no longer match position 0).
+    if (skip_count > 0) {
+        tokens.erase(tokens.begin(), tokens.begin() + skip_count);
+    }
+
     // hardware
     void* payload = pixel_values.size() > 0 ? static_cast<void*>(&pixel_values) : nullptr;
 
-    // process image first
+    // process image first (relative to trimmed tokens)
     int last_image_token_index = -1;
-    for (int i = 0; i < tokens.size(); i++) {
+    for (int i = 0; i < (int)tokens.size(); i++) {
         if (tokens[i] == IMAGE_TOKEN_ID) {
             last_image_token_index = i;
         }

--- a/src/common/AutoModel/modeling_gemma3_text.cpp
+++ b/src/common/AutoModel/modeling_gemma3_text.cpp
@@ -73,12 +73,6 @@ bool Gemma3_Text_Only::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& i
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
     
-    // some models are very sensitive to this bos token, such as lfm2
-    if (this->is_first_prompt == false) {
-        tokens.erase(tokens.begin()); // remove bos token in multi round conversation
-    }
-    this->is_first_prompt = false; // always set to false if the insert is ever called
-
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
 

--- a/src/common/AutoModel/modeling_gemma4e.cpp
+++ b/src/common/AutoModel/modeling_gemma4e.cpp
@@ -301,9 +301,107 @@ bool Gemma4e::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std
       
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
 
-    // find the last image token index
+    // ----------------------------------------------------------------------
+    // Prompt-cache aware multi-modal alignment.
+    //
+    // AutoModel::_shared_insert prefix-matches `tokens` against `token_history`
+    // and erases the matched prefix before prefilling. Without intervention,
+    // the multi-modal payload (which carries pixels/spectrograms for the
+    // WHOLE prompt, including images/audios from earlier turns that are
+    // already in the KV cache) would be misaligned with the surviving image
+    // and audio tokens. Compute the prefix-skip here, drop fully-cached
+    // leading images/audios from the payloads, and trim `tokens` so
+    // _shared_insert's own prefix check becomes a no-op.
+    // ----------------------------------------------------------------------
+    {
+        const size_t hist_size = this->token_history.size();
+        const size_t cmp_n = std::min(hist_size, tokens.size());
+        size_t skip_count = 0;
+        for (size_t i = 0; i < cmp_n; i++) {
+            if (tokens[i] == this->token_history[i]) {
+                skip_count++;
+            } else {
+                break;
+            }
+        }
+
+        if (skip_count > 0 && (image_payload.num_images > 0 || audio_payload.num_audios > 0)) {
+            // Count modal soft-tokens that landed inside the cached prefix.
+            int skipped_image_tokens = 0;
+            int skipped_audio_tokens = 0;
+            for (size_t i = 0; i < skip_count; i++) {
+                if (tokens[i] == image_token_id) skipped_image_tokens++;
+                else if (tokens[i] == audio_token_id) skipped_audio_tokens++;
+            }
+
+            // Walk images in order; each image's soft-token block is either
+            // entirely inside the cached prefix or not at all (chat-template
+            // boundaries never split a single image's block).
+            size_t images_to_drop = 0;
+            {
+                int consumed = 0;
+                for (unsigned i = 0; i < image_payload.num_images; i++) {
+                    const int n = static_cast<int>(image_payload.num_soft_tokens_per_image[i]);
+                    if (consumed + n <= skipped_image_tokens) {
+                        consumed += n;
+                        images_to_drop++;
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            // Same for audios.
+            size_t audios_to_drop = 0;
+            {
+                int consumed = 0;
+                for (unsigned i = 0; i < audio_payload.num_audios; i++) {
+                    const int n = static_cast<int>(audio_payload.num_soft_tokens_per_audio[i]);
+                    if (consumed + n <= skipped_audio_tokens) {
+                        consumed += n;
+                        audios_to_drop++;
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            auto drop_front = [](auto& vec, size_t n) {
+                if (n == 0) return;
+                if (n >= vec.size()) { vec.clear(); return; }
+                vec.erase(vec.begin(), vec.begin() + n);
+            };
+
+            if (images_to_drop > 0) {
+                drop_front(image_payload.image_patch__element_per_patch, images_to_drop);
+                drop_front(image_payload.valid_patch_size_per_image,     images_to_drop);
+                drop_front(image_payload.pixel_values,                   images_to_drop);
+                drop_front(image_payload.image_grid_pairs_per_image,     images_to_drop);
+                drop_front(image_payload.num_soft_tokens_per_image,      images_to_drop);
+                image_payload.num_images -= static_cast<unsigned>(images_to_drop);
+                header_print("FLM",
+                    "Prompt-cache hit: dropped " << images_to_drop
+                    << " cached image(s) from payload");
+            }
+
+            if (audios_to_drop > 0) {
+                drop_front(audio_payload.mel_spectrograms,                audios_to_drop);
+                drop_front(audio_payload.mel_spectrogram_frames_per_audio, audios_to_drop);
+                drop_front(audio_payload.mel_spectrogram_bins_per_audio,   audios_to_drop);
+                drop_front(audio_payload.num_soft_tokens_per_audio,        audios_to_drop);
+                audio_payload.num_audios -= static_cast<unsigned>(audios_to_drop);
+                header_print("FLM",
+                    "Prompt-cache hit: dropped " << audios_to_drop
+                    << " cached audio(s) from payload");
+            }
+
+            tokens.erase(tokens.begin(), tokens.begin() + skip_count);
+        }
+    }
+
+    // find the last image token index (relative to the (possibly) trimmed tokens)
     int last_image_token_index = -1;
-    for (int i = 0; i < tokens.size(); i++) {
+    for (int i = 0; i < (int)tokens.size(); i++) {
         if ((tokens[i] == image_token_id || tokens[i] == boi_token_id)) {
             last_image_token_index = i;
         }
@@ -324,7 +422,107 @@ bool Gemma4e::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std
 }
 
 std::string Gemma4e::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
-    return this->_shared_generate(meta_info, length_limit, os, is_cancelled);
+    std::vector<int> sampled_tokens;
+    std::string result;
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
+
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
+
+    // Skip pushing reasoning-related tokens (<|channel>...<channel|> Pattern: 100 ... 101) into token_history. 
+    bool in_think_block = false;
+    bool skip_next_newline_after_think = false;
+    auto push_history_filtered = [&](int token) {
+        if (skip_next_newline_after_think) {
+            skip_next_newline_after_think = false;
+        }
+        if (token == this->think_start_id) {
+            in_think_block = true;
+            return;
+        }
+        if (in_think_block) {
+            if (token == this->think_end_id) {
+                in_think_block = false;
+                skip_next_newline_after_think = true;
+            }
+            return;
+        }
+        if (token == 1) { // skip tool eos token
+            return;
+        }
+        this->token_history.push_back(token);
+    };
+    push_history_filtered(this->last_token);
+
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
+
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            // reset stream content 
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
+
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
+
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){ // filter out special tokens
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
+    return result;
 }
 
 std::string Gemma4e::generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os) {

--- a/src/common/AutoModel/modeling_gpt_oss.cpp
+++ b/src/common/AutoModel/modeling_gpt_oss.cpp
@@ -81,111 +81,248 @@ bool GPT_OSS::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std
 
 }
 
-
 std::string GPT_OSS::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
-    const std::string MARKER_TOOL_START = "<|start|>assistant<|channel|>commentary";
-    bool is_constrained_mode = false;
-
     os << "<|start|>" << std::flush;
     os << "assistant" << std::flush;
-    std::string result = this->_shared_generate(meta_info, length_limit, os, is_cancelled);
-    //std::vector<int> sampled_tokens;
-    //std::string result;
-    //if (length_limit > 0) {
-    //    sampled_tokens.reserve(length_limit);
-    //}
-    //else {
-    //    sampled_tokens.reserve(4096);
-    //}
-    //assert(this->last_token != -1);
+    std::vector<int> sampled_tokens;
+    std::string result;
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
 
-    //stop_reason_t reason = EOT_DETECTED;
-    //int last_sampled_token = this->last_token;
-    //this->token_history.push_back(this->last_token);
-    //auto decoding_start_time = time_utils::now();
-    //if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1) {
-    //    std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
-    //    result += token_str;
-    //    os << token_str << std::flush;
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
 
-    //}
-    //if (this->is_eos(last_sampled_token)) {
-    //    return result;
-    //}
-    //this->profiler_list[TKOEN_DECODE_TIME].stop(1);
-    //if (this->total_tokens >= this->MAX_L) {
-    //    header_print("WARNING", "Max length reached, stopping generation...");
-    //    reason = MAX_LENGTH_REACHED;
-    //    return result;
-    //}
-    //while (this->total_tokens < this->MAX_L) {
-    //    if (is_cancelled()) {
-    //        reason = CANCEL_DETECTED;
-    //        // reset stream content 
-    //        buffer_.clear();
-    //        current_mode_ = StreamEventType::CONTENT;
-    //        waiting_for_header_ = true;
-    //        break;
-    //    }
-    //    this->profiler_list[DECODING_TIME].start();
-    //    buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
-    //    this->profiler_list[DECODING_TIME].stop(1);
+    // Skip pushing reasoning-related tokens (<|channel|>analysis<|message|>The user says "hi". The assistant should respond politely. We can greet back.<|end|><|start|>assistant) into token_history.
+    // 35644: analysis, 200005: <|channel|>, 200008: <|message|>, 200007: <|end|>, 200006: <|start|>, 173781: assistant
+    // State machine to drop the entire analysis block including the trailing <|end|><|start|>assistant.
+    enum SkipState { SKIP_NONE, SKIP_SAW_CHANNEL, SKIP_IN_ANALYSIS, SKIP_SAW_END, SKIP_SAW_START };
+    SkipState skip_state = SKIP_NONE;
+    auto push_history_filtered = [&](int token) {
+        switch (skip_state) {
+            case SKIP_NONE:
+                if (token == 200005) { // <|channel|>
+                    skip_state = SKIP_SAW_CHANNEL;
+                    return; // hold back until we know which channel this is
+                }
+                if (token == 200002)
+                    return; // skip <|return|>
+                this->token_history.push_back(token);
+                return;
+            case SKIP_SAW_CHANNEL:
+                if (token == 35644) { // analysis -> begin skipping
+                    skip_state = SKIP_IN_ANALYSIS;
+                    return;
+                }
+                // Not the analysis channel: flush the held <|channel|> and current token.
+                this->token_history.push_back(200005);
+                this->token_history.push_back(token);
+                skip_state = SKIP_NONE;
+                return;
+            case SKIP_IN_ANALYSIS:
+                if (token == 200007) { // <|end|>
+                    skip_state = SKIP_SAW_END;
+                }
+                return; // drop everything inside the analysis block
+            case SKIP_SAW_END:
+                if (token == 200006) { // <|start|>
+                    skip_state = SKIP_SAW_START;
+                    return;
+                }
+                // Unexpected token after <|end|>; resume normal handling.
+                skip_state = SKIP_NONE;
+                this->token_history.push_back(token);
+                return;
+            case SKIP_SAW_START:
+                if (token == 173781) { // assistant -> finished skipping the header
+                    skip_state = SKIP_NONE;
+                    return;
+                }
+                // Unexpected: resume normal handling.
+                skip_state = SKIP_NONE;
+                this->token_history.push_back(token);
+                return;
+        }
+    };
 
-    //    this->profiler_list[SAMPLING_TIME].start();
-    //    // if MARKER_TOOL_START found 
-    //    
-    //    if (!is_constrained_mode) {
-    //        if (result.length() >= MARKER_TOOL_START.length() &&
-    //            result.compare(result.length() - MARKER_TOOL_START.length(), MARKER_TOOL_START.length(), MARKER_TOOL_START) == 0) {
-    //            is_constrained_mode = true;
-    //            reset_tool_grammar_state();
-    //            header_print("INFO", "<|start|>assistant<|channel|>commentary detected! Switching to Constrained Decoding.");
-    //        }
-    //    }
+    push_history_filtered(this->last_token);
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
 
-    //    int sampled_token;
-    //    if (is_constrained_mode) {
-    //        sampled_token = _sample_in_tool(y);
-    //        if (current_state == STATE_COMPLETE) {
-    //            is_constrained_mode = false;
-    //            header_print("INFO", "Constrained Decoding complete, returning to normal mode");
-    //        }
-    //    }
-    //    else
-    //        sampled_token = this->sampler->sample(y);
-    //    this->profiler_list[SAMPLING_TIME].stop(1);
-    //    this->total_tokens++;
-    //    last_sampled_token = sampled_token;
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            // reset stream content 
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
 
-    //    this->profiler_list[TKOEN_DECODE_TIME].start();
-    //    this->profiler_list[TKOEN_DECODE_TIME].stop(1);
-    //    if (this->is_normal_token(sampled_token)) { // filter out special tokens
-    //        std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
-    //        os << token_str << std::flush;
-    //        result += token_str;
-    //    }
-    //    this->token_history.push_back(sampled_token);
-    //    if (this->is_eos(sampled_token)) {
-    //        this->lm_engine->forward(last_sampled_token);
-    //        break;
-    //    }
-    //    meta_info.generated_tokens++;
-    //    if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)) {
-    //        reason = MAX_LENGTH_REACHED;
-    //        break;
-    //    }
-    //}
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
 
-    //auto decoding_end_time = time_utils::now();
-    //meta_info.decoding_duration = (uint64_t)time_utils::duration_ns(decoding_start_time, decoding_end_time).first;
-    //meta_info.stop_reason = reason;
-    //if (this->total_tokens >= this->MAX_L) {
-    //    header_print("WARNING", "Max length reached, stopping generation...");
-    //}
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){ // filter out special tokens
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
 
     os << "<|end|>" << std::flush;
     return "<|start|>assistant" + result + "<|end|>";
 }
+
+/*
+// std::string GPT_OSS::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
+//     const std::string MARKER_TOOL_START = "<|start|>assistant<|channel|>commentary";
+//     bool is_constrained_mode = false;
+
+//     os << "<|start|>" << std::flush;
+//     os << "assistant" << std::flush;
+//     std::string result = this->_shared_generate(meta_info, length_limit, os, is_cancelled);
+//     //std::vector<int> sampled_tokens;
+//     //std::string result;
+//     //if (length_limit > 0) {
+//     //    sampled_tokens.reserve(length_limit);
+//     //}
+//     //else {
+//     //    sampled_tokens.reserve(4096);
+//     //}
+//     //assert(this->last_token != -1);
+
+//     //stop_reason_t reason = EOT_DETECTED;
+//     //int last_sampled_token = this->last_token;
+//     //this->token_history.push_back(this->last_token);
+//     //auto decoding_start_time = time_utils::now();
+//     //if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1) {
+//     //    std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+//     //    result += token_str;
+//     //    os << token_str << std::flush;
+
+//     //}
+//     //if (this->is_eos(last_sampled_token)) {
+//     //    return result;
+//     //}
+//     //this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+//     //if (this->total_tokens >= this->MAX_L) {
+//     //    header_print("WARNING", "Max length reached, stopping generation...");
+//     //    reason = MAX_LENGTH_REACHED;
+//     //    return result;
+//     //}
+//     //while (this->total_tokens < this->MAX_L) {
+//     //    if (is_cancelled()) {
+//     //        reason = CANCEL_DETECTED;
+//     //        // reset stream content 
+//     //        buffer_.clear();
+//     //        current_mode_ = StreamEventType::CONTENT;
+//     //        waiting_for_header_ = true;
+//     //        break;
+//     //    }
+//     //    this->profiler_list[DECODING_TIME].start();
+//     //    buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+//     //    this->profiler_list[DECODING_TIME].stop(1);
+
+//     //    this->profiler_list[SAMPLING_TIME].start();
+//     //    // if MARKER_TOOL_START found 
+//     //    
+//     //    if (!is_constrained_mode) {
+//     //        if (result.length() >= MARKER_TOOL_START.length() &&
+//     //            result.compare(result.length() - MARKER_TOOL_START.length(), MARKER_TOOL_START.length(), MARKER_TOOL_START) == 0) {
+//     //            is_constrained_mode = true;
+//     //            reset_tool_grammar_state();
+//     //            header_print("INFO", "<|start|>assistant<|channel|>commentary detected! Switching to Constrained Decoding.");
+//     //        }
+//     //    }
+
+//     //    int sampled_token;
+//     //    if (is_constrained_mode) {
+//     //        sampled_token = _sample_in_tool(y);
+//     //        if (current_state == STATE_COMPLETE) {
+//     //            is_constrained_mode = false;
+//     //            header_print("INFO", "Constrained Decoding complete, returning to normal mode");
+//     //        }
+//     //    }
+//     //    else
+//     //        sampled_token = this->sampler->sample(y);
+//     //    this->profiler_list[SAMPLING_TIME].stop(1);
+//     //    this->total_tokens++;
+//     //    last_sampled_token = sampled_token;
+
+//     //    this->profiler_list[TKOEN_DECODE_TIME].start();
+//     //    this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+//     //    if (this->is_normal_token(sampled_token)) { // filter out special tokens
+//     //        std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+//     //        os << token_str << std::flush;
+//     //        result += token_str;
+//     //    }
+//     //    this->token_history.push_back(sampled_token);
+//     //    if (this->is_eos(sampled_token)) {
+//     //        this->lm_engine->forward(last_sampled_token);
+//     //        break;
+//     //    }
+//     //    meta_info.generated_tokens++;
+//     //    if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)) {
+//     //        reason = MAX_LENGTH_REACHED;
+//     //        break;
+//     //    }
+//     //}
+
+//     //auto decoding_end_time = time_utils::now();
+//     //meta_info.decoding_duration = (uint64_t)time_utils::duration_ns(decoding_start_time, decoding_end_time).first;
+//     //meta_info.stop_reason = reason;
+//     //if (this->total_tokens >= this->MAX_L) {
+//     //    header_print("WARNING", "Max length reached, stopping generation...");
+//     //}
+
+//     os << "<|end|>" << std::flush;
+//     return "<|start|>assistant" + result + "<|end|>";
+// }
+*/
 
 std::string GPT_OSS::generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os) {
     if (!this->insert(meta_info, input)) {

--- a/src/common/AutoModel/modeling_lfm2.cpp
+++ b/src/common/AutoModel/modeling_lfm2.cpp
@@ -75,12 +75,6 @@ bool LFM2::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std::f
     }
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
-    
-    // some models are very sensitive to this bos token, such as lfm2
-    if (this->is_first_prompt == false) {
-        tokens[0] = 708; // replace bos token with "\n" token in multi round conversation
-    }
-    this->is_first_prompt = false; // always set to false if the insert is ever called
 
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
@@ -338,24 +332,132 @@ bool LFM2_5_TK::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, s
     }
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
-    
-    // some models are very sensitive to this bos token, such as lfm2
-    if (this->is_first_prompt == false) {
-        tokens[0] = 708; // replace bos token with "\n" token in multi round conversation
-    }
-    this->is_first_prompt = false; // always set to false if the insert is ever called
 
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
 
     // hardware
-    return this->_shared_insert(meta_info, tokens, is_cancelled);
+    bool success = this->_shared_insert(meta_info, tokens, is_cancelled);
+
+    // Remove the starting reasoning placeholder appended by the chat template: "<think>\n" -> token ids 151667 198.
+    {
+        auto& hist = this->token_history;
+        size_t n = hist.size();
+        if (n >= 2 &&
+            hist[n - 2] == this->think_start_id &&
+            hist[n - 1] == 708) {
+            hist.resize(n - 2);
+        }
+    }
+
+    return success;
 }
 
 
 std::string LFM2_5_TK::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
-    os << "<think>\n" << std::flush;
-    std::string result = this->_shared_generate(meta_info, length_limit, os, is_cancelled);
-    result = "<think>\n" + result;
+    std::vector<int> sampled_tokens;
+    std::string result;
+    os << "<think>\n\n";
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
+
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
+
+    // The chat template already emits <think> before generation, so the model
+    // is always inside the reasoning block at the start. Skip pushing every
+    // token into token_history until (and including) think_end_id is produced;
+    // also drop the immediate "\n\n" (271) after </think>.
+    bool reasoning_done = false;
+    bool skip_next_newline_after_think = false;
+    auto push_history_filtered = [&](int token) {
+        if (!reasoning_done) {
+            if (token == this->think_end_id) {
+                reasoning_done = true;
+                skip_next_newline_after_think = true;
+            }
+            return; // skip everything up to and including </think>
+        }
+        if (skip_next_newline_after_think) {
+            skip_next_newline_after_think = false;
+            if (token == 509) { // skip the "\n\n" right after </think>
+                return;
+            }
+            if (token == 708) { // skip the "\n" right after </think>
+                return;
+            }
+        }
+        this->token_history.push_back(token);
+    };
+
+    push_history_filtered(this->last_token);
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
+
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            // reset stream content 
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
+
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
+
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){ // filter out special tokens
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
+    result = "<think>\n\n" + result;
     return result;
 }
 

--- a/src/common/AutoModel/modeling_llama3.cpp
+++ b/src/common/AutoModel/modeling_llama3.cpp
@@ -70,12 +70,6 @@ bool Llama3::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std:
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
 
-    // some models are very sensitive to this bos token, such as lfm2
-    if (this->is_first_prompt == false) {
-        tokens.erase(tokens.begin()); // remove bos token in multi round conversation
-    }
-    this->is_first_prompt = false; // always set to false if the insert is ever called
-
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
 
@@ -160,21 +154,124 @@ bool DeepSeek_r1_8b::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& inp
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
 
-    // some models are very sensitive to this bos token, such as lfm2
-    if (this->is_first_prompt == false) {
-        tokens.erase(tokens.begin()); // remove bos token in multi round conversation
-    }
-    this->is_first_prompt = false; // always set to false if the insert is ever called
-
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
+    // always remove first token
+    tokens.erase(tokens.begin());
+    bool success = this->_shared_insert(meta_info, tokens, is_cancelled);
 
-    return this->_shared_insert(meta_info, tokens, is_cancelled);
+    // Remove the trailing reasoning placeholder appended by the chat template:
+    // \n" -> token ids [198].
+    {
+        auto& hist = this->token_history;
+        size_t n = hist.size();
+        if (n >= 1 &&
+            hist[n - 1] == this->newline_id) {
+            hist.resize(n - 1);
+        }
+    }
+
+    return success;
 }
 
 std::string DeepSeek_r1_8b::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
+    std::vector<int> sampled_tokens;
+    std::string result;
     os << "<think>\n\n";
-    std::string result = this->_shared_generate(meta_info, length_limit, os, is_cancelled);
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
+
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
+
+
+    // Skip pushing every token into token_history until (and including) think_end_id is produced;
+    // also drop the immediate "\n" right after </think>.
+    bool reasoning_done = false;
+    bool skip_next_newline_after_think = false;
+    auto push_history_filtered = [&](int token) {
+        if (!reasoning_done) {
+            if (token == this->think_end_id) {
+                reasoning_done = true;
+                skip_next_newline_after_think = true;
+            }
+            return; // skip everything up to and including </think>
+        }
+        if (skip_next_newline_after_think) {
+            skip_next_newline_after_think = false;
+            if (token == this->double_newline_id) { // skip the "\n\n" right after </think>
+                return;
+            }
+        }
+        this->token_history.push_back(token);
+    };
+
+    push_history_filtered(this->last_token);
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
+
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
+
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
     result = "<think>\n\n" + result;
     return result;
 }

--- a/src/common/AutoModel/modeling_nanbeige.cpp
+++ b/src/common/AutoModel/modeling_nanbeige.cpp
@@ -84,14 +84,6 @@ bool Nanbeige::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, st
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
 
-    std::cout << std::endl;
-
-    // some models are very sensitive to this bos token, such as lfm2
-    if (this->is_first_prompt == false) {
-        tokens.erase(tokens.begin()); // remove bos token in multi round conversation
-    }
-    this->is_first_prompt = false; // always set to false if the insert is ever called
-
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
 

--- a/src/common/AutoModel/modeling_qwen2.cpp
+++ b/src/common/AutoModel/modeling_qwen2.cpp
@@ -72,10 +72,7 @@ bool Qwen2::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std::
     }
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
-    if (this->is_first_prompt == false) {
-        tokens.insert(tokens.begin(), 198);
-    }
-    this->is_first_prompt = false;
+
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
 
@@ -91,110 +88,4 @@ std::string Qwen2::generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_
         return "";
     }
     return this->_shared_generate(meta_info, length_limit, os);
-}
-
-// Non-stream
-NonStreamResult Qwen2::parse_nstream_content(const std::string response_text) {
-    NonStreamResult result;
-
-    std::string name, arguments;
-
-    std::string start_tag = "<tool_call>";
-    std::string end_tag = "</tool_call>";
-
-    size_t start_pos = response_text.find(start_tag);
-    size_t end_pos = response_text.find(end_tag);
-
-    if (start_pos == std::string::npos || end_pos == std::string::npos) {
-        // pure content
-        result.content = response_text;
-        return result;
-    }
-
-    start_pos += start_tag.length();
-    std::string json_str = response_text.substr(start_pos, end_pos - start_pos);
-
-    // Parse "name" 
-    std::string key_name = "\"name\": \"";
-    size_t name_start = json_str.find(key_name);
-    if (name_start != std::string::npos) {
-        name_start += key_name.length();
-        size_t name_end = json_str.find("\"", name_start);
-        if (name_end != std::string::npos) {
-            name = json_str.substr(name_start, name_end - name_start);
-        }
-    }
-
-    // Parse "arguments"
-    std::string key_args = "\"arguments\":";
-    size_t args_pos = json_str.find(key_args);
-    if (args_pos != std::string::npos) {
-        size_t brace_start = json_str.find("{", args_pos);
-        size_t brace_end = json_str.rfind("}"); // Find the last closing brace
-
-        if (brace_start != std::string::npos && brace_end != std::string::npos && brace_end > brace_start) {
-            arguments = json_str.substr(brace_start, brace_end - brace_start);
-        }
-    }
-
-    result.tool_name = name;
-    result.tool_args = arguments;
-
-    return result;
-}
-
-// Stream
-StreamResult Qwen2::parse_stream_content(const std::string content) {
-    std::string tool_start_tag = "<tool_call>";
-    std::string tool_end_tag = "</tool_call>";
-
-    StreamResult result;
-    result.type = StreamEventType::CONTENT; 
-
-    if (content.find(tool_start_tag) != std::string::npos) {
-        is_in_tool_block_ = true;
-        tool_name_.clear();
-        result.type = StreamEventType::WAITING;
-        return result;
-    }
-
-    if (content.find("</tool_call>") != std::string::npos) {
-        is_in_tool_block_ = false;
-
-        try {
-            auto j = nlohmann::json::parse(tool_name_);
-
-            result.type = StreamEventType::TOOL_DONE;
-            //result.tool_id = generate_id();
-            result.tool_id = "call_" + std::to_string(std::time(nullptr));
-
-            if (j.contains("name")) {
-                result.tool_name = j["name"].get<std::string>();
-            }
-
-            if (j.contains("arguments")) {
-                if (j["arguments"].is_string()) {
-                    result.tool_args_str = j["arguments"].get<std::string>();
-                }
-                else {
-                    result.tool_args_str = j["arguments"].dump();
-                }
-            }
-        }
-        catch (...) {
-            result.type = StreamEventType::CONTENT;
-            result.content = "[Error parsing tool call]";
-        }
-        return result;
-    }
-
-    if (is_in_tool_block_) {
-        tool_name_ += content;
-        result.type = StreamEventType::WAITING; 
-        return result;
-    }
-
-    result.content = content;
-    return result;
-
 }

--- a/src/common/AutoModel/modeling_qwen2vl.cpp
+++ b/src/common/AutoModel/modeling_qwen2vl.cpp
@@ -202,7 +202,9 @@ bool Qwen2VL::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std
     // update the tokens to include the image tokens
     std::vector<int> tokens;
     int total_image_tokens = 0;
-    for (int i = 0; i < input.images.size(); i++) {
+    // Use image_payload.images.size() (not input.images.size()), because on
+    // the REST API path images come from `messages` and input.images is empty.
+    for (size_t i = 0; i < image_payload.images.size(); i++) {
         total_image_tokens += image_payload.images[i].grid_h * image_payload.images[i].grid_w;
     }
     tokens.reserve(tokens_init.size() + total_image_tokens);
@@ -219,9 +221,78 @@ bool Qwen2VL::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std
     }
 
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
-    // process image first
+
+    // ----------------------------------------------------------------------
+    // Prompt-cache aware image alignment.
+    //
+    // AutoModel::_shared_insert prefix-matches `tokens` against `token_history`
+    // and erases the matched prefix before prefilling. Without intervention,
+    // the image payload (pixels for the WHOLE prompt, including already-cached
+    // images from earlier turns) would be misaligned with the surviving image
+    // tokens. Compute the prefix-skip here, drop fully-cached leading images
+    // from image_payload, and trim `tokens` so _shared_insert's own prefix
+    // check is a no-op.
+    // ----------------------------------------------------------------------
+    {
+        const size_t hist_size = this->token_history.size();
+        const size_t cmp_n = std::min(hist_size, tokens.size());
+        size_t skip_count = 0;
+        for (size_t i = 0; i < cmp_n; i++) {
+            if (tokens[i] == this->token_history[i]) {
+                skip_count++;
+            } else {
+                break;
+            }
+        }
+
+        if (skip_count > 0 && !image_payload.images.empty()) {
+            int skipped_image_tokens = 0;
+            for (size_t i = 0; i < skip_count; i++) {
+                if (tokens[i] == image_soft_token_id) skipped_image_tokens++;
+            }
+
+            size_t images_to_drop = 0;
+            size_t bf16_to_drop = 0;
+            int consumed_image_tokens = 0;
+            for (const auto& img : image_payload.images) {
+                const int img_tokens = (img.grid_h * img.grid_w) / 4;
+                const size_t img_bf16 =
+                    static_cast<size_t>(img.grid_h) * QWEN2_PATCH_SIZE *
+                    static_cast<size_t>(img.grid_w) * QWEN2_PATCH_SIZE *
+                    3u * QWEN2_TEMPORAL_PATCH_SIZE;
+                if (consumed_image_tokens + img_tokens <= skipped_image_tokens) {
+                    consumed_image_tokens += img_tokens;
+                    bf16_to_drop += img_bf16;
+                    images_to_drop++;
+                } else {
+                    break;
+                }
+            }
+
+            if (images_to_drop > 0) {
+                image_payload.images.erase(
+                    image_payload.images.begin(),
+                    image_payload.images.begin() + images_to_drop);
+                image_payload.num_images -= static_cast<int>(images_to_drop);
+                if (bf16_to_drop >= image_payload._data__processed.size()) {
+                    image_payload._data__processed.clear();
+                } else {
+                    image_payload._data__processed.erase(
+                        image_payload._data__processed.begin(),
+                        image_payload._data__processed.begin() + bf16_to_drop);
+                }
+                header_print_g("FLM",
+                    "Prompt-cache hit: dropped " + std::to_string(images_to_drop)
+                    + " cached image(s) from payload");
+            }
+
+            tokens.erase(tokens.begin(), tokens.begin() + skip_count);
+        }
+    }
+
+    // process image first (relative to the (possibly) trimmed tokens)
     int last_image_token_index = -1;
-    for (int i = 0; i < tokens.size(); i++) {
+    for (int i = 0; i < (int)tokens.size(); i++) {
         if (tokens[i] == image_soft_token_id) {
             last_image_token_index = i;
         }

--- a/src/common/AutoModel/modeling_qwen3.cpp
+++ b/src/common/AutoModel/modeling_qwen3.cpp
@@ -77,19 +77,130 @@ bool Qwen3::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std::
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
 
-    if (this->is_first_prompt == false) {
-        tokens.insert(tokens.begin(), 198);
-    }
-    this->is_first_prompt = false;
-
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
 
-    return this->_shared_insert(meta_info, tokens, is_cancelled);
+    bool success = this->_shared_insert(meta_info, tokens, is_cancelled);
+
+    // Remove the trailing reasoning placeholder appended by the chat template when
+    // thinking is disabled: "<think>\n\n</think>\n\n" -> token ids 151667 271 151668 271.
+    {
+        auto& hist = this->token_history;
+        size_t n = hist.size();
+        if (n >= 4 &&
+            hist[n - 4] == this->think_start_id &&
+            hist[n - 3] == 271 &&
+            hist[n - 2] == this->think_end_id &&
+            hist[n - 1] == 271) {
+            hist.resize(n - 4);
+        }
+    }
+
+    return success;
 }
 
 std::string Qwen3::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
-    return this->_shared_generate(meta_info, length_limit, os, is_cancelled);
+    std::vector<int> sampled_tokens;
+    std::string result;
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
+
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
+
+    // Skip pushing reasoning-related tokens (<think>...</think> and the trailing "\n\n" Pattern: 151667 271 151668 271) into token_history. 
+    bool in_think_block = false;
+    bool skip_next_newline_after_think = false;
+    auto push_history_filtered = [&](int token) {
+        if (skip_next_newline_after_think) {
+            skip_next_newline_after_think = false;
+            if (token == 271) {
+                return; // skip the "\n\n" right after </think>
+            }
+        }
+        if (token == this->think_start_id) {
+            in_think_block = true;
+            return;
+        }
+        if (in_think_block) {
+            if (token == this->think_end_id) {
+                in_think_block = false;
+                skip_next_newline_after_think = true;
+            }
+            return;
+        }
+        this->token_history.push_back(token);
+    };
+
+    push_history_filtered(this->last_token);
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
+
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            // reset stream content 
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
+
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
+
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){ // filter out special tokens
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
+    return result;
 }
 
 std::string Qwen3::generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os) {
@@ -232,10 +343,7 @@ bool Qwen3_IT::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, st
     }
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
-    if (this->is_first_prompt == false) {
-        tokens.insert(tokens.begin(), 198);
-    }
-    this->is_first_prompt = false;
+
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
 
@@ -423,20 +531,126 @@ bool Qwen3_TK::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, st
     }
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
-      if (this->is_first_prompt == false) {
-        tokens.insert(tokens.begin(), 198);
-    }
-    this->is_first_prompt = false;
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
+    bool success = this->_shared_insert(meta_info, tokens, is_cancelled);
 
-    return this->_shared_insert(meta_info, tokens, is_cancelled);
+    // Remove the starting reasoning placeholder appended by the chat template: "<think>\n" -> token ids 151667 198.
+    {
+        auto& hist = this->token_history;
+        size_t n = hist.size();
+        if (n >= 2 &&
+            hist[n - 2] == this->think_start_id &&
+            hist[n - 1] == 198) {
+            hist.resize(n - 2);
+        }
+    }
+
+    return success;
+
 }
 
 std::string Qwen3_TK::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
+    std::vector<int> sampled_tokens;
     std::string result;
     os << "<think>\n\n";
-    result = this->_shared_generate(meta_info, length_limit, os, is_cancelled);
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
+
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
+
+    // The chat template already emits <think> before generation, so the model
+    // is always inside the reasoning block at the start. Skip pushing every
+    // token into token_history until (and including) think_end_id is produced;
+    // also drop the immediate "\n\n" (271) after </think>.
+    bool reasoning_done = false;
+    bool skip_next_newline_after_think = false;
+    auto push_history_filtered = [&](int token) {
+        if (!reasoning_done) {
+            if (token == this->think_end_id) {
+                reasoning_done = true;
+                skip_next_newline_after_think = true;
+            }
+            return; // skip everything up to and including </think>
+        }
+        if (skip_next_newline_after_think) {
+            skip_next_newline_after_think = false;
+            if (token == 271) { // skip the "\n\n" right after </think>
+                return;
+            }
+        }
+        this->token_history.push_back(token);
+    };
+
+    push_history_filtered(this->last_token);
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
+
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            // reset stream content 
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
+
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
+
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){ // filter out special tokens
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
     result = "<think>\n\n" + result;
     return result;
 }
@@ -581,10 +795,7 @@ bool DeepSeek_r1_0528_8b::insert(chat_meta_info_t& meta_info, lm_uniform_input_t
     }
 
     std::vector<int> tokens = this->tokenizer->encode(templated_text);
-    if (this->is_first_prompt == false) {
-        tokens.insert(tokens.begin(), 198);
-    }
-    this->is_first_prompt = false;
+
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
     // hardware
 
@@ -592,7 +803,106 @@ bool DeepSeek_r1_0528_8b::insert(chat_meta_info_t& meta_info, lm_uniform_input_t
 }
 
 std::string DeepSeek_r1_0528_8b::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
-    std::string result = this->_shared_generate(meta_info, length_limit, os, is_cancelled);
+    std::vector<int> sampled_tokens;
+    std::string result;
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
+
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
+
+    // Skip pushing reasoning-related tokens (<think>...</think> and the trailing "\n" Pattern: 151667 ... 151668 198) into token_history.
+    bool in_think_block = false;
+    bool skip_next_newline_after_think = false;
+    auto push_history_filtered = [&](int token) {
+        if (skip_next_newline_after_think) {
+            skip_next_newline_after_think = false;
+            if (token == 198) {
+                return; // skip the "\n" right after </think>
+            }
+        }
+        if (token == this->think_start_id) {
+            in_think_block = true;
+            return;
+        }
+        if (in_think_block) {
+            if (token == this->think_end_id) {
+                in_think_block = false;
+                skip_next_newline_after_think = true;
+            }
+            return;
+        }
+        this->token_history.push_back(token);
+    };
+
+    push_history_filtered(this->last_token);
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
+
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            // reset stream content 
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
+
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
+
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){ // filter out special tokens
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
     return result;
 }
 

--- a/src/common/AutoModel/modeling_qwen3_5vl.cpp
+++ b/src/common/AutoModel/modeling_qwen3_5vl.cpp
@@ -161,7 +161,9 @@ bool Qwen3_5VL::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, s
     // update the tokens to include the image tokens
     std::vector<int> tokens;
     int total_image_tokens = 0;
-    for (int i = 0; i < input.images.size(); i++) {
+    // Use image_payload.images.size() (not input.images.size()), because on
+    // the REST API path images come from `messages` and input.images is empty.
+    for (size_t i = 0; i < image_payload.images.size(); i++) {
         total_image_tokens += image_payload.images[i].grid_h * image_payload.images[i].grid_w;
     }
     tokens.reserve(tokens_init.size() + total_image_tokens);
@@ -179,9 +181,83 @@ bool Qwen3_5VL::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, s
 
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
 
-    // find the last image token index
+    // ----------------------------------------------------------------------
+    // Prompt-cache aware image alignment.
+    //
+    // AutoModel::_shared_insert prefix-matches `tokens` against `token_history`
+    // and erases the matched prefix before prefilling. Without intervention,
+    // the image payload (pixels for the WHOLE prompt, including already-cached
+    // images from earlier turns) would be misaligned with the surviving image
+    // tokens. Compute the prefix-skip here, drop fully-cached leading images
+    // from image_payload, and trim `tokens` so _shared_insert's own prefix
+    // check is a no-op.
+    // ----------------------------------------------------------------------
+    {
+        const size_t hist_size = this->token_history.size();
+        const size_t cmp_n = std::min(hist_size, tokens.size());
+        size_t skip_count = 0;
+        for (size_t i = 0; i < cmp_n; i++) {
+            if (tokens[i] == this->token_history[i]) {
+                skip_count++;
+            } else {
+                break;
+            }
+        }
+
+        if (skip_count > 0 && !image_payload.images.empty()) {
+            // Per-image bf16 footprint depends on runtime patch/temporal
+            // config carried by the engine.
+            auto* eng = reinterpret_cast<qwen3_5vl_npu*>(this->lm_engine.get());
+            const unsigned patch_size = eng->QWEN3_5_PATCH_SIZE;
+            const unsigned temporal_patch = eng->QWEN3_5_TEMPORAL_PATCH_SIZE;
+
+            int skipped_image_tokens = 0;
+            for (size_t i = 0; i < skip_count; i++) {
+                if (tokens[i] == image_soft_token_id) skipped_image_tokens++;
+            }
+
+            size_t images_to_drop = 0;
+            size_t bf16_to_drop = 0;
+            int consumed_image_tokens = 0;
+            for (const auto& img : image_payload.images) {
+                const int img_tokens = (img.grid_h * img.grid_w) / 4;
+                const size_t img_bf16 =
+                    static_cast<size_t>(img.grid_h) * patch_size *
+                    static_cast<size_t>(img.grid_w) * patch_size *
+                    3u * temporal_patch;
+                if (consumed_image_tokens + img_tokens <= skipped_image_tokens) {
+                    consumed_image_tokens += img_tokens;
+                    bf16_to_drop += img_bf16;
+                    images_to_drop++;
+                } else {
+                    break;
+                }
+            }
+
+            if (images_to_drop > 0) {
+                image_payload.images.erase(
+                    image_payload.images.begin(),
+                    image_payload.images.begin() + images_to_drop);
+                image_payload.num_images -= static_cast<int>(images_to_drop);
+                if (bf16_to_drop >= image_payload._data__processed.size()) {
+                    image_payload._data__processed.clear();
+                } else {
+                    image_payload._data__processed.erase(
+                        image_payload._data__processed.begin(),
+                        image_payload._data__processed.begin() + bf16_to_drop);
+                }
+                header_print("FLM",
+                    "Prompt-cache hit: dropped " << images_to_drop
+                    << " cached image(s) from payload");
+            }
+
+            tokens.erase(tokens.begin(), tokens.begin() + skip_count);
+        }
+    }
+
+    // find the last image token index (relative to the (possibly) trimmed tokens)
     int last_image_token_index = -1;
-    for (int i = 0; i < tokens.size(); i++) {
+    for (int i = 0; i < (int)tokens.size(); i++) {
         if (tokens[i] == image_soft_token_id) {
             last_image_token_index = i;
         }
@@ -191,18 +267,167 @@ bool Qwen3_5VL::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, s
 
     // hardware
     if (image_payload.num_images > 0){
-        return this->_shared_insert(meta_info, tokens, is_cancelled, &image_payload, last_image_token_index);
-    }else{
-        return this->_shared_insert(meta_info, tokens, is_cancelled, nullptr);
-    }
+        bool success =  this->_shared_insert(meta_info, tokens, is_cancelled, &image_payload, last_image_token_index);
+        {
+            auto& hist = this->token_history;
+            size_t n = hist.size();
+            if (this->enable_think) {
+                if (n >= 2 &&
+                    hist[n - 2] == this->think_start_id &&
+                    hist[n - 1] == 198) {
+                    hist.resize(n - 2);
+                }
+            }
+            else {
+                if (n >= 4 &&
+                    hist[n - 4] == this->think_start_id &&
+                    hist[n - 3] == 271 &&
+                    hist[n - 2] == this->think_end_id &&
+                    hist[n - 1] == 271) {
+                    hist.resize(n - 4);
+                }
+            }
 
+        }
+        return success;
+    }else{
+        bool success = this->_shared_insert(meta_info, tokens, is_cancelled);
+        {
+            auto& hist = this->token_history;
+            size_t n = hist.size();
+            if (this->enable_think) {
+                if (n >= 2 &&
+                    hist[n - 2] == this->think_start_id &&
+                    hist[n - 1] == 198) {
+                    hist.resize(n - 2);
+                }
+            }
+            else {
+                if (n >= 4 &&
+                    hist[n - 4] == this->think_start_id &&
+                    hist[n - 3] == 271 &&
+                    hist[n - 2] == this->think_end_id &&
+                    hist[n - 1] == 271) {
+                    hist.resize(n - 4);
+                }
+            }
+
+        }
+        return success;
+    }
 }
 
 std::string Qwen3_5VL::generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled) {
+    std::vector<int> sampled_tokens;
+    std::string result;
     if (this->enable_think) {
         os << "<think>\n" << std::flush;
     }
-    return this->_shared_generate(meta_info, length_limit, os, is_cancelled);
+    if (length_limit > 0){
+        sampled_tokens.reserve(length_limit);
+    }
+    else{
+        sampled_tokens.reserve(4096);
+    }
+    assert(this->last_token != -1);
+
+    stop_reason_t reason = EOT_DETECTED;
+    int last_sampled_token = this->last_token;
+
+    // The chat template already emits <think> before generation, so the model
+    // is always inside the reasoning block at the start. Skip pushing every
+    // token into token_history until (and including) think_end_id is produced;
+    // also drop the immediate "\n\n" (271) after </think>.
+    bool reasoning_done = false;
+    bool skip_next_newline_after_think = false;
+    auto push_history_filtered = [&](int token) {
+        if (this->enable_think) {
+            if (!reasoning_done) {
+                if (token == this->think_end_id) {
+                    reasoning_done = true;
+                    skip_next_newline_after_think = true;
+                }
+                return; // skip everything up to and including </think>
+            }
+            if (skip_next_newline_after_think) {
+                skip_next_newline_after_think = false;
+                if (token == 271) { // skip the "\n\n" right after </think>
+                    return;
+                }
+            }
+        }
+        this->token_history.push_back(token);
+    };
+
+    push_history_filtered(this->last_token);
+    if (this->is_normal_token(last_sampled_token) && last_sampled_token != -1){
+        std::string token_str = this->tokenizer->run_time_decoder(last_sampled_token);
+        result += token_str;
+        os << token_str << std::flush;
+
+    }
+    if (this->is_eos(last_sampled_token)){
+        return result;
+    }
+    this->profiler_list[DECODING_TIME].reset();
+    this->profiler_list[TKOEN_DECODE_TIME].reset();
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+        reason = MAX_LENGTH_REACHED;
+        return result;
+    }
+    while (this->total_tokens < this->MAX_L){
+        if (is_cancelled()) {
+            reason = CANCEL_DETECTED;
+            // reset stream content 
+            buffer_.clear();
+            current_mode_ = StreamEventType::CONTENT;
+            tool_name_.clear();
+            is_in_tool_block_ = false;
+            break;
+        }
+        this->profiler_list[DECODING_TIME].start();
+        buffer<bf16> y = this->lm_engine->forward(last_sampled_token);
+        this->profiler_list[DECODING_TIME].stop(1);
+
+        this->profiler_list[SAMPLING_TIME].start();
+        int sampled_token = this->sampler->sample(y);
+        this->profiler_list[SAMPLING_TIME].stop(1);
+        this->total_tokens++;
+        last_sampled_token = sampled_token;
+
+        this->profiler_list[TKOEN_DECODE_TIME].start();
+        if (this->is_normal_token(sampled_token)){ // filter out special tokens
+            std::string token_str = this->tokenizer->run_time_decoder(sampled_token);
+            os << token_str << std::flush;
+            result += token_str;
+        }
+        this->profiler_list[TKOEN_DECODE_TIME].stop(1);
+        push_history_filtered(sampled_token);
+        if (this->is_eos(sampled_token)){
+            meta_info.generated_tokens++;
+            this->lm_engine->forward(last_sampled_token);
+            break;
+        }
+        meta_info.generated_tokens++;
+        if ((length_limit > 0) && (meta_info.generated_tokens >= length_limit)){
+            reason = MAX_LENGTH_REACHED;
+            break;
+        }
+    }
+    meta_info.decoding_duration = (uint64_t)(time_utils::cast_to_us(this->profiler_list[DECODING_TIME].get_total_time()).first) * 1e3;
+    meta_info.stop_reason = reason;
+    if (this->total_tokens >= this->MAX_L){
+        header_print("WARNING", "Max length reached, stopping generation...");
+    }
+    
+    if(this->enable_think) {
+        result = "<think>\n" + result;
+    } 
+    std::cout << std::endl;
+    header_print("FLM", "Model RAW Output: \n" + result);
+    
+    return result;
 }
 
 std::string Qwen3_5VL::generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os) {

--- a/src/common/AutoModel/modeling_qwen3vl.cpp
+++ b/src/common/AutoModel/modeling_qwen3vl.cpp
@@ -158,7 +158,9 @@ bool Qwen3VL::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std
     // update the tokens to include the image tokens
     std::vector<int> tokens;
     int total_image_tokens = 0;
-    for (int i = 0; i < input.images.size(); i++) {
+    // Use image_payload.images.size() (not input.images.size()), because on
+    // the REST API path images come from `messages` and input.images is empty.
+    for (size_t i = 0; i < image_payload.images.size(); i++) {
         total_image_tokens += image_payload.images[i].grid_h * image_payload.images[i].grid_w;
     }
     tokens.reserve(tokens_init.size() + total_image_tokens);
@@ -176,9 +178,83 @@ bool Qwen3VL::insert(chat_meta_info_t& meta_info, lm_uniform_input_t& input, std
 
     this->profiler_list[TKOEN_ENCODE_TIME].stop(tokens.size());
 
-    // find the last image token index
+    // ----------------------------------------------------------------------
+    // Prompt-cache aware image alignment.
+    //
+    // AutoModel::_shared_insert prefix-matches `tokens` against `token_history`
+    // and erases the matched prefix before prefilling. If we leave that to
+    // _shared_insert, the image payload (which carries pixels for the WHOLE
+    // prompt, including already-cached images from earlier turns) will be
+    // misaligned with the surviving image tokens. Compute the prefix-skip
+    // here, drop fully-cached leading images from image_payload, and trim
+    // `tokens` so _shared_insert's own prefix-skip becomes a no-op.
+    // ----------------------------------------------------------------------
+    {
+        const size_t hist_size = this->token_history.size();
+        const size_t cmp_n = std::min(hist_size, tokens.size());
+        size_t skip_count = 0;
+        for (size_t i = 0; i < cmp_n; i++) {
+            if (tokens[i] == this->token_history[i]) {
+                skip_count++;
+            } else {
+                break;
+            }
+        }
+
+        if (skip_count > 0 && !image_payload.images.empty()) {
+            // Count image-soft tokens in the cached prefix.
+            int skipped_image_tokens = 0;
+            for (size_t i = 0; i < skip_count; i++) {
+                if (tokens[i] == image_soft_token_id) skipped_image_tokens++;
+            }
+
+            // Walk through images and drop those whose entire token block
+            // sits within the cached prefix. (The chat-template prefix
+            // boundary always falls between messages, so an image's token
+            // block is never partially cached.)
+            size_t images_to_drop = 0;
+            size_t bf16_to_drop = 0;
+            int consumed_image_tokens = 0;
+            for (const auto& img : image_payload.images) {
+                const int img_tokens =
+                    (img.grid_h * img.grid_w) / 4;
+                const size_t img_bf16 =
+                    static_cast<size_t>(img.grid_h) * QWEN3_PATCH_SIZE *
+                    static_cast<size_t>(img.grid_w) * QWEN3_PATCH_SIZE *
+                    3u * QWEN3_TEMPORAL_PATCH_SIZE;
+                if (consumed_image_tokens + img_tokens <= skipped_image_tokens) {
+                    consumed_image_tokens += img_tokens;
+                    bf16_to_drop += img_bf16;
+                    images_to_drop++;
+                } else {
+                    break;
+                }
+            }
+
+            if (images_to_drop > 0) {
+                image_payload.images.erase(
+                    image_payload.images.begin(),
+                    image_payload.images.begin() + images_to_drop);
+                image_payload.num_images -= static_cast<int>(images_to_drop);
+                if (bf16_to_drop >= image_payload._data__processed.size()) {
+                    image_payload._data__processed.clear();
+                } else {
+                    image_payload._data__processed.erase(
+                        image_payload._data__processed.begin(),
+                        image_payload._data__processed.begin() + bf16_to_drop);
+                }
+                header_print("FLM",
+                    "Prompt-cache hit: dropped " << images_to_drop
+                    << " cached image(s) from payload");
+            }
+
+            tokens.erase(tokens.begin(), tokens.begin() + skip_count);
+        }
+    }
+
+    // find the last image token index (relative to the (possibly) trimmed tokens)
     int last_image_token_index = -1;
-    for (int i = 0; i < tokens.size(); i++) {
+    for (int i = 0; i < (int)tokens.size(); i++) {
         if (tokens[i] == image_soft_token_id) {
             last_image_token_index = i;
         }

--- a/src/include/AutoModel/automodel.hpp
+++ b/src/include/AutoModel/automodel.hpp
@@ -142,7 +142,6 @@ protected:
 	xrt::device* npu_device_inst = nullptr;
 	std::unique_ptr<npu_xclbin_manager> npu = nullptr;
 	bool enable_preemption = false;
-	bool is_first_prompt; // for remove bos token in multi-round conversation
 
 	uint32_t MAX_L = 0;
 	int last_token = -1;

--- a/src/include/AutoModel/modeling_gemma4e.hpp
+++ b/src/include/AutoModel/modeling_gemma4e.hpp
@@ -33,6 +33,9 @@ private:
     static constexpr int audio_token_id = 258881; // audio token id
     static constexpr int eoa_token_id = 258883; // end of audio token id
 
+    static constexpr int think_start_id = 100;
+    static constexpr int think_end_id = 101;
+
     bool enable_think = false;
     bool enable_tool = false;
     void setup_tokenizer(std::string model_path);

--- a/src/include/AutoModel/modeling_lfm2.hpp
+++ b/src/include/AutoModel/modeling_lfm2.hpp
@@ -37,6 +37,9 @@ public:
 
 class LFM2_5_TK : public AutoModel {
 private:
+    int think_start_id = 64400;
+    int think_end_id = 64401;
+
     void setup_tokenizer(std::string model_path);
     inline std::string _replace_space(std::string& text){
         static std::string to_replace = "Ġ";

--- a/src/include/AutoModel/modeling_llama3.hpp
+++ b/src/include/AutoModel/modeling_llama3.hpp
@@ -29,6 +29,10 @@ class DeepSeek_r1_8b : public AutoModel {
 private:
     std::string current_model = "DeepSeek_r1_8b";
     int think_marker_id;
+    int think_start_id = 128013; // placeholder token id for "<think>"
+    int think_end_id = 128014;   // placeholder token id for "</think>"
+    int newline_id = 198;        // token id for "\n"
+    int double_newline_id = 271; // token id for "\n\n"
     void setup_tokenizer(std::string model_path);
 
 public:

--- a/src/include/AutoModel/modeling_qwen2.hpp
+++ b/src/include/AutoModel/modeling_qwen2.hpp
@@ -25,6 +25,4 @@ public:
     std::string generate(chat_meta_info_t& meta_info, int length_limit, std::ostream& os, std::function<bool()> is_cancelled = [] { return false; }) override;
     std::string generate_with_prompt(chat_meta_info_t& meta_info, lm_uniform_input_t& input, int length_limit, std::ostream& os = std::cout) override;
     std::string apply_chat_template(nlohmann::ordered_json& messages, nlohmann::ordered_json tools = nlohmann::ordered_json::object()) override;
-    NonStreamResult parse_nstream_content(const std::string response_text);
-    StreamResult parse_stream_content(const std::string content);
 };

--- a/src/include/AutoModel/modeling_qwen3.hpp
+++ b/src/include/AutoModel/modeling_qwen3.hpp
@@ -16,6 +16,11 @@ private:
     bool enable_think = false;
     bool enable_tool = false;
     
+    int think_start_id = 151667;
+    int think_end_id = 151668;
+
+    // bool skip_push_history = false;
+
     void setup_tokenizer(std::string model_path);
 
 public:
@@ -97,6 +102,8 @@ private:
     std::string current_model = "Qwen3_TK";
 
     int think_marker_id;
+    int think_start_id = 151667;
+    int think_end_id = 151668;
 
     void setup_tokenizer(std::string model_path);
 
@@ -120,7 +127,9 @@ private:
     std::string current_model = "DeepSeek_r1_0528_8b";
 
     int think_marker_id;
-
+    int think_start_id = 151667;
+    int think_end_id = 151668;
+    
     void setup_tokenizer(std::string model_path);
 
 public:

--- a/src/include/AutoModel/modeling_qwen3_5vl.hpp
+++ b/src/include/AutoModel/modeling_qwen3_5vl.hpp
@@ -26,6 +26,8 @@ private:
 
     bool enable_think = false;
     bool enable_tool = false;
+    int think_start_id = 248068;
+    int think_end_id = 248069;
     void setup_tokenizer(std::string model_path);
     
     // Image processing functionality

--- a/src/include/minja/chat-template.hpp
+++ b/src/include/minja/chat-template.hpp
@@ -1,3 +1,7 @@
+// Copied from https://github.com/google/minja/blob/main/include/minja/chat-template.hpp Commit 5be6f88
+ 
+
+
 /*
     Copyright 2024 Google LLC
 
@@ -22,9 +26,9 @@
 #include <string>
 #include <vector>
 
-#include "nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 
-using o_json = nlohmann::ordered_json;
+using json = nlohmann::ordered_json;
 
 namespace minja {
 
@@ -121,26 +125,26 @@ class chat_template {
 
         const std::string user_needle = "<User Needle>";
         const std::string sys_needle = "<System Needle>";
-        const o_json dummy_str_user_msg = {{"role", "user"}, {"content", user_needle}};
-        const o_json dummy_typed_user_msg = {{"role", "user"}, {"content", o_json::array({{{"type", "text"}, {"text", user_needle}}})}};
+        const json dummy_str_user_msg = {{"role", "user"}, {"content", user_needle}};
+        const json dummy_typed_user_msg = {{"role", "user"}, {"content", json::array({{{"type", "text"}, {"text", user_needle}}})}};
 
         caps_.requires_typed_content =
-            !contains(try_raw_render(o_json::array({dummy_str_user_msg}), {}, false), user_needle)
-            && contains(try_raw_render(o_json::array({dummy_typed_user_msg}), {}, false), user_needle);
+            !contains(try_raw_render(json::array({dummy_str_user_msg}), {}, false), user_needle)
+            && contains(try_raw_render(json::array({dummy_typed_user_msg}), {}, false), user_needle);
 
         const auto dummy_user_msg = caps_.requires_typed_content
             ? dummy_typed_user_msg
             : dummy_str_user_msg;
-        const o_json needle_system_msg = {
+        const json needle_system_msg = {
             {"role", "system"},
-            {"content", caps_.requires_typed_content ? o_json::array({{{"type", "text"}, {"text", sys_needle}}}) : o_json(sys_needle)},
+            {"content", caps_.requires_typed_content ? json::array({{{"type", "text"}, {"text", sys_needle}}}) : json(sys_needle)},
         };
 
         caps_.supports_system_role = contains(try_raw_render({needle_system_msg, dummy_user_msg,}, {}, false), sys_needle);
 
-        auto out = try_raw_render(o_json::array({
+        auto out = try_raw_render(json::array({
             dummy_user_msg
-        }), o_json::array({
+        }), json::array({
             {
                 {"name", "some_tool"},
                 {"type", "function"},
@@ -155,22 +159,34 @@ class chat_template {
                                 {"description", "Some argument."},
                             }},
                         }},
-                        {"required", o_json::array({ "arg" })},
+                        {"required", json::array({ "arg" })},
                     }},
                 }},
             },
         }), false);
         caps_.supports_tools = contains(out, "some_tool");
 
-        auto make_tool_calls_msg = [&](const o_json & tool_calls) {
-            return o_json {
+        const auto render_with_content = [&](const json & content) {
+            const json assistant_msg {{"role", "assistant"}, {"content", content}};
+            // Render two assistant messages as some templates like QwQ-32B are handling
+            // the content differently depending on whether it's the last message or not
+            // (to remove the <think> tag in all but the last message).
+            return try_raw_render(json::array({dummy_user_msg, assistant_msg, dummy_user_msg, assistant_msg}), {}, false);
+        };
+        auto out_empty = render_with_content("");
+        auto out_null = render_with_content(json());
+        caps_.requires_non_null_content = contains(out_empty, user_needle) && !contains(out_null, user_needle);
+        
+        json j_null;
+        auto make_tool_calls_msg = [&](const json & tool_calls) {
+            return json {
                 {"role", "assistant"},
-                {"content", nullptr},
+                {"content", caps_.requires_non_null_content? "" : j_null},
                 {"tool_calls", tool_calls},
             };
         };
-        auto make_tool_call = [](const std::string & tool_name, const o_json & arguments) {
-            return o_json {
+        auto make_tool_call = [](const std::string & tool_name, const json & arguments) {
+            return json {
                 {"id", "call_1___"},
                 {"type", "function"},
                 {"function", {
@@ -179,39 +195,36 @@ class chat_template {
                 }},
             };
         };
-        const o_json dummy_args_obj {{"argument_needle", "print('Hello, World!')"}};
+        const json dummy_args_obj {{"argument_needle", "print('Hello, World!')"}};
 
         // Note: the arguments are rendered in both cases, but may be double-escaped, which we don't want.
-        out = try_raw_render(o_json::array({
+        out = try_raw_render(json::array({
             dummy_user_msg,
-            make_tool_calls_msg(o_json::array({make_tool_call("ipython", dummy_args_obj.dump())})),
+            make_tool_calls_msg(json::array({make_tool_call("ipython", dummy_args_obj.dump())})),
         }), {}, false);
-        auto tool_call_renders_str_arguments = contains(out, "\"argument_needle\":") || contains(out, "'argument_needle':");
-        out = try_raw_render(o_json::array({
+        auto tool_call_renders_str_arguments = contains(out, "<parameter=argument_needle>") || contains(out, "\"argument_needle\":") || contains(out, "'argument_needle':");
+        out = try_raw_render(json::array({
             dummy_user_msg,
-            make_tool_calls_msg(o_json::array({make_tool_call("ipython", dummy_args_obj)})),
+            make_tool_calls_msg(json::array({make_tool_call("ipython", dummy_args_obj)})),
         }), {}, false);
-        auto tool_call_renders_obj_arguments = contains(out, "\"argument_needle\":") || contains(out, "'argument_needle':");
+        auto tool_call_renders_obj_arguments = contains(out, "<parameter=argument_needle>") || contains(out, "\"argument_needle\":") || contains(out, "'argument_needle':");
 
         caps_.supports_tool_calls = tool_call_renders_str_arguments || tool_call_renders_obj_arguments;
         caps_.requires_object_arguments = !tool_call_renders_str_arguments && tool_call_renders_obj_arguments;
-        auto out_empty = try_raw_render(o_json::array({dummy_user_msg, {{"role", "assistant"}, {"content", ""}}}), {}, false);
-        auto out_null = try_raw_render(o_json::array({dummy_user_msg, {{"role", "assistant"}, {"content", nullptr}}}), {}, false);
-        caps_.requires_non_null_content = contains(out_empty, user_needle) && !contains(out_null, user_needle);
 
         if (caps_.supports_tool_calls) {
-            auto dummy_args = caps_.requires_object_arguments ? dummy_args_obj : o_json(dummy_args_obj.dump());
+            auto dummy_args = caps_.requires_object_arguments ? dummy_args_obj : json(dummy_args_obj.dump());
             auto tc1 = make_tool_call("test_tool1", dummy_args);
             auto tc2 = make_tool_call("test_tool2", dummy_args);
-            auto out = try_raw_render(o_json::array({
+            auto out = try_raw_render(json::array({
                 dummy_user_msg,
-                make_tool_calls_msg(o_json::array({tc1, tc2})),
+                make_tool_calls_msg(json::array({tc1, tc2})),
             }), {}, false);
             caps_.supports_parallel_tool_calls = contains(out, "test_tool1") && contains(out, "test_tool2");
 
-            out = try_raw_render(o_json::array({
+            out = try_raw_render(json::array({
                 dummy_user_msg,
-                make_tool_calls_msg(o_json::array({tc1})),
+                make_tool_calls_msg(json::array({tc1})),
                 {
                     {"role", "tool"},
                     {"name", "test_tool1"},
@@ -225,24 +238,24 @@ class chat_template {
 
         try {
             if (!caps_.supports_tools) {
-                const o_json user_msg {
+                const json user_msg {
                     {"role", "user"},
                     {"content", "Hey"},
                 };
-                const o_json args {
+                const json args {
                     {"arg1", "some_value"},
                 };
-                const o_json tool_call_msg {
+                const json tool_call_msg {
                     {"role", "assistant"},
-                    {"content", nullptr},
-                    {"tool_calls", o_json::array({
+                    {"content", caps_.requires_non_null_content ? "" : j_null},
+                    {"tool_calls", json::array({
                         {
                             // TODO: detect if requires numerical id or fixed length == 6 like Nemo
                             {"id", "call_1___"},
                             {"type", "function"},
                             {"function", {
                                 {"name", "tool_name"},
-                                {"arguments", (caps_.requires_object_arguments ? args : o_json(minja::Value(args).dump(-1, /* to_json= */ true)))},
+                                {"arguments", (caps_.requires_object_arguments ? args : json(minja::Value(args).dump(-1, /* to_json= */ true)))},
                             }},
                         },
                     })},
@@ -250,13 +263,13 @@ class chat_template {
                 std::string prefix, full;
                 {
                     chat_template_inputs inputs;
-                    inputs.messages = o_json::array({user_msg});
+                    inputs.messages = json::array({user_msg});
                     inputs.add_generation_prompt = true;
                     prefix = apply(inputs);
                 }
                 {
                     chat_template_inputs inputs;
-                    inputs.messages = o_json::array({user_msg, tool_call_msg});
+                    inputs.messages = json::array({user_msg, tool_call_msg});
                     inputs.add_generation_prompt = false;
                     full = apply(inputs);
                 }
@@ -321,7 +334,7 @@ class chat_template {
         const chat_template_inputs & inputs,
         const chat_template_options & opts = chat_template_options()) const
     {
-        o_json actual_messages;
+        json actual_messages;
 
         auto has_tools = inputs.tools.is_array() && !inputs.tools.empty();
         auto has_tool_calls = false;
@@ -357,9 +370,9 @@ class chat_template {
         );
 
         if (needs_polyfills) {
-            actual_messages = o_json::array();
+            actual_messages = json::array();
 
-            auto add_message = [&](const o_json & msg) {
+            auto add_message = [&](const json & msg) {
                 if (polyfill_typed_content && msg.contains("content") && !msg.at("content").is_null() && msg.at("content").is_string()) {
                     actual_messages.push_back({
                         {"role", msg.at("role")},
@@ -384,7 +397,7 @@ class chat_template {
                 }
             };
 
-            o_json adjusted_messages;
+            json adjusted_messages;
             if (polyfill_tools) {
                 adjusted_messages = add_system(inputs.messages,
                     "You can call any of the following tools to satisfy the user's requests: " + minja::Value(inputs.tools).dump(2, /* to_json= */ true) +
@@ -408,7 +421,7 @@ class chat_template {
                                 auto & arguments = function.at("arguments");
                                 if (arguments.is_string()) {
                                     try {
-                                        arguments = o_json::parse(arguments.get<std::string>());
+                                        arguments = json::parse(arguments.get<std::string>());
                                     } catch (const std::exception & ecvt) {
                                         fprintf(stderr, "Failed to parse arguments: %s\n", ecvt.what());
                                     }
@@ -417,13 +430,13 @@ class chat_template {
                         }
                     }
                     if (polyfill_tool_calls) {
-                        auto tool_calls = o_json::array();
+                        auto tool_calls = json::array();
                         for (const auto & tool_call : message.at("tool_calls")) {
                             if (tool_call.at("type") != "function") {
                                 continue;
                             }
                             const auto & function = tool_call.at("function");
-                            auto tc = o_json {
+                            auto tc = json {
                                 {"name", function.at("name")},
                                 {"arguments", function.at("arguments")},
                             };
@@ -432,7 +445,7 @@ class chat_template {
                             }
                             tool_calls.push_back(tc);
                         }
-                        auto obj = o_json {
+                        auto obj = json {
                             {"tool_calls", tool_calls},
                         };
                         if (message.contains("content")) {
@@ -447,8 +460,8 @@ class chat_template {
                 }
                 if (polyfill_tool_responses && role == "tool") {
                     message["role"] = "user";
-                    auto obj = o_json {
-                        {"tool_response", o_json::object()},
+                    auto obj = json {
+                        {"tool_response", json::object()},
                     };
                     if (message.contains("name")) {
                         obj["tool_response"]["tool"] = message.at("name");
@@ -485,7 +498,7 @@ class chat_template {
             actual_messages = inputs.messages;
         }
 
-        auto context = minja::Context::make(o_json({
+        auto context = minja::Context::make(json({
             {"messages", actual_messages},
             {"add_generation_prompt", inputs.add_generation_prompt},
         }));
@@ -520,16 +533,16 @@ class chat_template {
     }
 
     static nlohmann::ordered_json add_system(const nlohmann::ordered_json & messages, const std::string & system_prompt) {
-        o_json messages_with_system = messages;
+        json messages_with_system = messages;
 
         if (!messages_with_system.empty() && messages_with_system[0].at("role") == "system") {
             std::string existing_system = messages_with_system.at(0).at("content");
-            messages_with_system[0] = o_json {
+            messages_with_system[0] = json {
                 {"role", "system"},
                 {"content", existing_system + "\n\n" + system_prompt},
             };
         } else {
-            messages_with_system.insert(messages_with_system.begin(), o_json {
+            messages_with_system.insert(messages_with_system.begin(), json {
                 {"role", "system"},
                 {"content", system_prompt},
             });

--- a/src/include/minja/minja.hpp
+++ b/src/include/minja/minja.hpp
@@ -1,3 +1,7 @@
+// Copied from https://github.com/google/minja/blob/main/include/minja/minja.hpp Commit 3e4c61c
+  
+
+
 /*
     Copyright 2024 Google LLC
 
@@ -29,9 +33,9 @@
 #include <utility>
 #include <vector>
 
-#include "nlohmann/json.hpp"
+#include <nlohmann/json.hpp>
 
-using o_json = nlohmann::ordered_json;
+using json = nlohmann::ordered_json;
 
 namespace minja {
 
@@ -61,27 +65,27 @@ public:
   using FilterType = std::function<Value(const std::shared_ptr<Context> &, ArgumentsValue &)>;
 
 private:
-  using ObjectType = nlohmann::ordered_map<o_json, Value>;  // Only contains primitive keys
+  using ObjectType = nlohmann::ordered_map<json, Value>;  // Only contains primitive keys
   using ArrayType = std::vector<Value>;
 
   std::shared_ptr<ArrayType> array_;
   std::shared_ptr<ObjectType> object_;
   std::shared_ptr<CallableType> callable_;
-  o_json primitive_;
+  json primitive_;
 
   Value(const std::shared_ptr<ArrayType> & array) : array_(array) {}
   Value(const std::shared_ptr<ObjectType> & object) : object_(object) {}
   Value(const std::shared_ptr<CallableType> & callable) : object_(std::make_shared<ObjectType>()), callable_(callable) {}
 
   /* Python-style string repr */
-  static void dump_string(const o_json & primitive, std::ostringstream & out, char string_quote = '\'') {
+  static void dump_string(const json & primitive, std::ostringstream & out, char string_quote = '\'') {
     if (!primitive.is_string()) throw std::runtime_error("Value is not a string: " + primitive.dump());
     auto s = primitive.dump();
     if (string_quote == '"' || s.find('\'') != std::string::npos) {
       out << s;
       return;
     }
-    // Reuse o_json dump, just changing string quotes
+    // Reuse json dump, just changing string quotes
     out << string_quote;
     for (size_t i = 1, n = s.size() - 1; i < n; ++i) {
       if (s[i] == '\\' && s[i + 1] == '"') {
@@ -155,7 +159,7 @@ public:
   Value(const std::string & v) : primitive_(v) {}
   Value(const char * v) : primitive_(std::string(v)) {}
 
-  Value(const o_json & v) {
+  Value(const json & v) {
     if (v.is_object()) {
       auto object = std::make_shared<ObjectType>();
       for (auto it = v.begin(); it != v.end(); ++it) {
@@ -541,23 +545,23 @@ struct ArgumentsValue {
 };
 
 template <>
-inline o_json Value::get<o_json>() const {
+inline json Value::get<json>() const {
   if (is_primitive()) return primitive_;
-  if (is_null()) return o_json();
+  if (is_null()) return json();
   if (array_) {
-    std::vector<o_json> res;
+    std::vector<json> res;
     for (const auto& item : *array_) {
-      res.push_back(item.get<o_json>());
+      res.push_back(item.get<json>());
     }
     return res;
   }
   if (object_) {
-    o_json res = o_json::object();
+    json res = json::object();
     for (const auto& [key, value] : *object_) {
       if (key.is_string()) {
-        res[key.get<std::string>()] = value.get<o_json>();
+        res[key.get<std::string>()] = value.get<json>();
       } else if (key.is_primitive()) {
-        res[key.dump()] = value.get<o_json>();
+        res[key.dump()] = value.get<json>();
       } else {
         throw std::runtime_error("Invalid key type for conversion to JSON: " + key.dump());
       }
@@ -578,7 +582,7 @@ namespace std {
     size_t operator()(const minja::Value & v) const {
       if (!v.is_hashable())
         throw std::runtime_error("Unsupported type for hashing: " + v.dump());
-      return std::hash<o_json>()(v.get<o_json>());
+      return std::hash<json>()(v.get<json>());
     }
   };
 } // namespace std
@@ -706,7 +710,7 @@ enum SpaceHandling { Keep, Strip, StripSpaces, StripNewline };
 
 class TemplateToken {
 public:
-    enum class Type { Text, Expression, If, Else, Elif, EndIf, For, EndFor, Generation, EndGeneration, Set, EndSet, Comment, Macro, EndMacro, Filter, EndFilter, Break, Continue };
+    enum class Type { Text, Expression, If, Else, Elif, EndIf, For, EndFor, Generation, EndGeneration, Set, EndSet, Comment, Macro, EndMacro, Filter, EndFilter, Break, Continue, Call, EndCall };
 
     static std::string typeToString(Type t) {
         switch (t) {
@@ -729,6 +733,8 @@ public:
             case Type::EndGeneration: return "endgeneration";
             case Type::Break: return "break";
             case Type::Continue: return "continue";
+            case Type::Call: return "call";
+            case Type::EndCall: return "endcall";
         }
         return "Unknown";
     }
@@ -844,6 +850,17 @@ public:
 struct LoopControlTemplateToken : public TemplateToken {
     LoopControlType control_type;
     LoopControlTemplateToken(const Location & loc, SpaceHandling pre, SpaceHandling post, LoopControlType control_type) : TemplateToken(Type::Break, loc, pre, post), control_type(control_type) {}
+};
+
+struct CallTemplateToken : public TemplateToken {
+    std::shared_ptr<Expression> expr;
+    CallTemplateToken(const Location & loc, SpaceHandling pre, SpaceHandling post, std::shared_ptr<Expression> && e) 
+        : TemplateToken(Type::Call, loc, pre, post), expr(std::move(e)) {}
+};
+
+struct EndCallTemplateToken : public TemplateToken {
+    EndCallTemplateToken(const Location & loc, SpaceHandling pre, SpaceHandling post) 
+        : TemplateToken(Type::EndCall, loc, pre, post) {}
 };
 
 class TemplateNode {
@@ -1050,31 +1067,36 @@ public:
     void do_render(std::ostringstream &, const std::shared_ptr<Context> & macro_context) const override {
         if (!name) throw std::runtime_error("MacroNode.name is null");
         if (!body) throw std::runtime_error("MacroNode.body is null");
-        auto callable = Value::callable([&](const std::shared_ptr<Context> & context, ArgumentsValue & args) {
-            auto call_context = macro_context;
+        auto callable = Value::callable([this, macro_context](const std::shared_ptr<Context> & call_context, ArgumentsValue & args) {
+            auto execution_context = Context::make(Value::object(), macro_context);
+
+            if (call_context->contains("caller")) {
+                execution_context->set("caller", call_context->get("caller"));
+            }
+
             std::vector<bool> param_set(params.size(), false);
             for (size_t i = 0, n = args.args.size(); i < n; i++) {
                 auto & arg = args.args[i];
                 if (i >= params.size()) throw std::runtime_error("Too many positional arguments for macro " + name->get_name());
                 param_set[i] = true;
                 auto & param_name = params[i].first;
-                call_context->set(param_name, arg);
+                execution_context->set(param_name, arg);
             }
             for (auto & [arg_name, value] : args.kwargs) {
                 auto it = named_param_positions.find(arg_name);
                 if (it == named_param_positions.end()) throw std::runtime_error("Unknown parameter name for macro " + name->get_name() + ": " + arg_name);
 
-                call_context->set(arg_name, value);
+                execution_context->set(arg_name, value);
                 param_set[it->second] = true;
             }
             // Set default values for parameters that were not passed
             for (size_t i = 0, n = params.size(); i < n; i++) {
                 if (!param_set[i] && params[i].second != nullptr) {
-                    auto val = params[i].second->evaluate(context);
-                    call_context->set(params[i].first, val);
+                    auto val = params[i].second->evaluate(call_context);
+                    execution_context->set(params[i].first, val);
                 }
             }
-            return body->render(call_context);
+            return body->render(execution_context);
         });
         macro_context->set(name->get_name(), callable);
     }
@@ -1291,6 +1313,12 @@ public:
     }
 };
 
+static bool in(const Value & value, const Value & container) {
+  return (((container.is_array() || container.is_object()) && container.contains(value)) ||
+      (value.is_string() && container.is_string() &&
+        container.to_str().find(value.to_str()) != std::string::npos));
+};                                    
+
 class BinaryOpExpr : public Expression {
 public:
     enum class Op { StrConcat, Add, Sub, Mul, MulMul, Div, DivDiv, Mod, Eq, Ne, Lt, Gt, Le, Ge, And, Or, In, NotIn, Is, IsNot };
@@ -1355,8 +1383,8 @@ public:
               case Op::Gt:        return l > r;
               case Op::Le:        return l <= r;
               case Op::Ge:        return l >= r;
-              case Op::In:        return (r.is_array() || r.is_object()) && r.contains(l);
-              case Op::NotIn:     return !(r.is_array() && r.contains(l));
+              case Op::In:        return in(l, r);
+              case Op::NotIn:     return !in(l, r);
               default:            break;
           }
           throw std::runtime_error("Unknown binary operator");
@@ -1495,6 +1523,13 @@ public:
           } else if (method->get_name() == "pop") {
             vargs.expectArgs("pop method", {1, 1}, {0, 0});
             return obj.pop(vargs.args[0]);
+          } else if (method->get_name() == "keys") {
+            vargs.expectArgs("keys method", {0, 0}, {0, 0});
+            auto result = Value::array();
+            for (const auto& key : obj.keys()) {
+              result.push_back(Value(key));
+            }
+            return result;
           } else if (method->get_name() == "get") {
             vargs.expectArgs("get method", {1, 2}, {0, 0});
             auto key = vargs.args[0];
@@ -1536,6 +1571,16 @@ public:
           } else if (method->get_name() == "capitalize") {
             vargs.expectArgs("capitalize method", {0, 0}, {0, 0});
             return Value(capitalize(str));
+          } else if (method->get_name() == "upper") {
+            vargs.expectArgs("upper method", {0, 0}, {0, 0});
+            auto result = str;
+            std::transform(result.begin(), result.end(), result.begin(), ::toupper);
+            return Value(result);
+          } else if (method->get_name() == "lower") {
+            vargs.expectArgs("lower method", {0, 0}, {0, 0});
+            auto result = str;
+            std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+            return Value(result);
           } else if (method->get_name() == "endswith") {
             vargs.expectArgs("endswith method", {1, 1}, {0, 0});
             auto suffix = vargs.args[0].get<std::string>();
@@ -1552,6 +1597,19 @@ public:
               else res[i] = std::tolower(res[i]);
             }
             return res;
+          } else if (method->get_name() == "replace") {
+            vargs.expectArgs("replace method", {2, 3}, {0, 0});
+            auto before = vargs.args[0].get<std::string>();
+            auto after = vargs.args[1].get<std::string>();
+            auto count = vargs.args.size() == 3 ? vargs.args[2].get<int64_t>()
+                                                : str.length();
+            size_t start_pos = 0;
+            while ((start_pos = str.find(before, start_pos)) != std::string::npos &&
+                  count-- > 0) {
+              str.replace(start_pos, before.length(), after);
+              start_pos += after.length();
+            }
+            return str;
           }
         }
         throw std::runtime_error("Unknown method: " + method->get_name());
@@ -1572,6 +1630,40 @@ public:
         }
         auto vargs = args.evaluate(context);
         return obj.call(context, vargs);
+    }
+};
+
+class CallNode : public TemplateNode {
+    std::shared_ptr<Expression> expr;
+    std::shared_ptr<TemplateNode> body;
+
+public:
+    CallNode(const Location & loc, std::shared_ptr<Expression> && e, std::shared_ptr<TemplateNode> && b)
+        : TemplateNode(loc), expr(std::move(e)), body(std::move(b)) {}
+
+    void do_render(std::ostringstream & out, const std::shared_ptr<Context> & context) const override {
+        if (!expr) throw std::runtime_error("CallNode.expr is null");
+        if (!body) throw std::runtime_error("CallNode.body is null");
+        
+        auto caller = Value::callable([this, context](const std::shared_ptr<Context> &, ArgumentsValue &) -> Value {
+            return Value(body->render(context));
+        });
+        
+        context->set("caller", caller);
+        
+        auto call_expr = dynamic_cast<CallExpr*>(expr.get());
+        if (!call_expr) {
+            throw std::runtime_error("Invalid call block syntax - expected function call");
+        }
+
+        Value function = call_expr->object->evaluate(context);
+        if (!function.is_callable()) {
+            throw std::runtime_error("Call target must be callable: " + function.dump());
+        }
+        ArgumentsValue args = call_expr->args.evaluate(context);
+        
+        Value result = function.call(context, args);
+        out << result.to_str();
     }
 };
 
@@ -1673,7 +1765,7 @@ private:
       return nullptr;
     }
 
-    o_json parseNumber(CharIterator& it, const CharIterator& end) {
+    json parseNumber(CharIterator& it, const CharIterator& end) {
         auto before = it;
         consumeSpaces();
         auto start = it;
@@ -1699,15 +1791,15 @@ private:
         }
         if (start == it) {
           it = before;
-          return o_json(); // No valid characters found
+          return json(); // No valid characters found
         }
 
         std::string str(start, it);
         try {
-          return o_json::parse(str);
-        } catch (o_json::parse_error& e) {
+          return json::parse(str);
+        } catch (json::parse_error& e) {
           throw std::runtime_error("Failed to parse number: '" + str + "' (" + std::string(e.what()) + ")");
-          return o_json();
+          return json();
         }
     }
 
@@ -2128,7 +2220,7 @@ private:
             }
           }
   
-          if ((has_first_colon || has_second_colon) && (start || end || step)) {
+          if ((has_first_colon || has_second_colon)) {
             index = std::make_shared<SliceExpr>(slice_loc, std::move(start), std::move(end), std::move(step));
           } else {
             index = std::move(start);
@@ -2284,7 +2376,7 @@ private:
       static std::regex comment_tok(R"(\{#([-~]?)([\s\S]*?)([-~]?)#\})");
       static std::regex expr_open_regex(R"(\{\{([-~])?)");
       static std::regex block_open_regex(R"(^\{%([-~])?\s*)");
-      static std::regex block_keyword_tok(R"((if|else|elif|endif|for|endfor|generation|endgeneration|set|endset|block|endblock|macro|endmacro|filter|endfilter|break|continue)\b)");
+      static std::regex block_keyword_tok(R"((if|else|elif|endif|for|endfor|generation|endgeneration|set|endset|block|endblock|macro|endmacro|filter|endfilter|break|continue|call|endcall)\b)");
       static std::regex non_text_open_regex(R"(\{\{|\{%|\{#)");
       static std::regex expr_close_regex(R"(\s*([-~])?\}\})");
       static std::regex block_close_regex(R"(\s*([-~])?%\})");
@@ -2407,6 +2499,15 @@ private:
             } else if (keyword == "endmacro") {
               auto post_space = parseBlockClose();
               tokens.push_back(std::make_unique<EndMacroTemplateToken>(location, pre_space, post_space));
+            } else if (keyword == "call") {
+              auto expr = parseExpression();
+              if (!expr) throw std::runtime_error("Expected expression in call block");
+
+              auto post_space = parseBlockClose();
+              tokens.push_back(std::make_unique<CallTemplateToken>(location, pre_space, post_space, std::move(expr)));
+            } else if (keyword == "endcall") {
+              auto post_space = parseBlockClose();
+              tokens.push_back(std::make_unique<EndCallTemplateToken>(location, pre_space, post_space));
             } else if (keyword == "filter") {
               auto filter = parseExpression();
               if (!filter) throw std::runtime_error("Expected expression in filter block");
@@ -2539,6 +2640,12 @@ private:
                   throw unterminated(**start);
               }
               children.emplace_back(std::make_shared<MacroNode>(token->location, std::move(macro_token->name), std::move(macro_token->params), std::move(body)));
+          } else if (auto call_token = dynamic_cast<CallTemplateToken*>(token.get())) {
+            auto body = parseTemplate(begin, it, end);
+            if (it == end || (*(it++))->type != TemplateToken::Type::EndCall) {
+                throw unterminated(**start);
+            }
+            children.emplace_back(std::make_shared<CallNode>(token->location, std::move(call_token->expr), std::move(body)));
           } else if (auto filter_token = dynamic_cast<FilterTemplateToken*>(token.get())) {
               auto body = parseTemplate(begin, it, end);
               if (it == end || (*(it++))->type != TemplateToken::Type::EndFilter) {
@@ -2552,6 +2659,7 @@ private:
           } else if (dynamic_cast<EndForTemplateToken*>(token.get())
                   || dynamic_cast<EndSetTemplateToken*>(token.get())
                   || dynamic_cast<EndMacroTemplateToken*>(token.get())
+                  || dynamic_cast<EndCallTemplateToken*>(token.get())
                   || dynamic_cast<EndFilterTemplateToken*>(token.get())
                   || dynamic_cast<EndIfTemplateToken*>(token.get())
                   || dynamic_cast<ElseTemplateToken*>(token.get())
@@ -2628,15 +2736,11 @@ inline std::shared_ptr<Context> Context::builtins() {
     auto items = Value::array();
     if (args.contains("object")) {
       auto & obj = args.at("object");
-      if (obj.is_string()) {
-        auto json_obj = o_json::parse(obj.get<std::string>());
-        for (const auto & kv : json_obj.items()) {
-          items.push_back(Value::array({kv.key(), kv.value()}));
-        }
-      } else if (!obj.is_null()) {
-        for (auto & key : obj.keys()) {
-          items.push_back(Value::array({key, obj.at(key)}));
-        }
+      if (!obj.is_object()) {
+        throw std::runtime_error("Can only get item pairs from a mapping");
+      }
+      for (auto & key : obj.keys()) {
+        items.push_back(Value::array({key, obj.at(key)}));
       }
     }
     return items;
@@ -2763,6 +2867,9 @@ inline std::shared_ptr<Context> Context::builtins() {
       auto & items = args.at("items");
       if (!items.is_array()) throw std::runtime_error("object is not iterable");
       return items;
+  }));
+  globals.set("in", simple_function("in", { "item", "items" }, [](const std::shared_ptr<Context> &, Value & args) -> Value {
+      return in(args.at("item"), args.at("items"));
   }));
   globals.set("unique", simple_function("unique", { "items" }, [](const std::shared_ptr<Context> &, Value & args) -> Value {
       auto & items = args.at("items");

--- a/src/include/prompt_cache.hpp
+++ b/src/include/prompt_cache.hpp
@@ -17,7 +17,17 @@ class PromptCache {
 private:
     uint64_t checksum_;
     std::vector<uint64_t> tool_checksums_;
-    bool can_use_tool_cache_;
+
+    uint64_t _calculate_message_checksum(const json& messages, size_t end) {
+        uint64_t checksum = 0;
+        const size_t message_count = std::min(end, messages.size());
+        for (size_t i = 0; i < message_count; ++i) {
+            const std::string message_string = messages[i].dump();
+            checksum = _calculate_checksum(message_string.data(), message_string.size(), checksum);
+        }
+        return checksum;
+    }
+
     std::vector<uint64_t> _calculate_tool_checksums(const json& tools) {
         std::vector<uint64_t> tool_checksums;
         tool_checksums.reserve(tools.size());
@@ -46,44 +56,30 @@ private:
 
         return _sum;
     }
+    
 public:
-    PromptCache() : checksum_(0), can_use_tool_cache_(true) {}
+    PromptCache() : checksum_(0), tool_checksums_() {}
 
-    json tool_checksum(json& tools) {
-        if (!tools.is_array() || tools.empty()) {
-            can_use_tool_cache_ = tool_checksums_.empty();
-            tool_checksums_.clear();
-            return tools;
-        }
-
+    bool can_use_tool_cache(json& tools) {
         std::vector<uint64_t> new_tool_checksums = _calculate_tool_checksums(tools);
 
-        can_use_tool_cache_ = tool_checksums_.size() <= new_tool_checksums.size();
-        for (size_t i = 0; can_use_tool_cache_ && i < tool_checksums_.size(); ++i) {
-            can_use_tool_cache_ = tool_checksums_[i] == new_tool_checksums[i];
-        }
-
-        json tools_to_insert = json::array();
-        if (can_use_tool_cache_) {
-            for (size_t i = tool_checksums_.size(); i < tools.size(); ++i) {
-                tools_to_insert.push_back(tools[i]);
+        if (tool_checksums_.size() == new_tool_checksums.size()){
+            for (size_t i = 0; i < tool_checksums_.size(); ++i) {
+                if (tool_checksums_[i] != new_tool_checksums[i]) {
+                    tool_checksums_ = std::move(new_tool_checksums);
+                    return false;
+                }
             }
+            return true;
         }
         else {
-            tools_to_insert = tools;
+            tool_checksums_ = std::move(new_tool_checksums);
+            return false;
         }
-
-        tool_checksums_ = std::move(new_tool_checksums);
-        return tools_to_insert;
-    }
-
-    bool can_use_tool_cache() const {
-        return can_use_tool_cache_;
     }
 
     void reset_tool_checksum() {
         tool_checksums_.clear();
-        can_use_tool_cache_ = true;
     }
 
     void update_tool_checksum(json& tools) {
@@ -93,31 +89,14 @@ public:
         }
 
         tool_checksums_ = _calculate_tool_checksums(tools);
-        can_use_tool_cache_ = true;
     }
 
 
-    bool can_use_cache(json& messages, chat_template_type_t template_type) {
-        uint64_t check_sum_to_compare = 0;
-        uint64_t new_checksum = 0;
+    bool can_use_message_cache(json& messages, chat_template_type_t template_type) {
+        (void)template_type;
         if (messages.size() > 2) {
-            for (size_t i = 0; i < messages.size(); ++i) {
-                const auto& msg = messages[i];
-                const std::string role = msg.value("role", "");
-                const std::string content = msg.value("content", "");
-
-                bool has_tool_call = msg.contains("tool_calls");
-                bool skip_this_message = (role == "tool") || has_tool_call;
-                if (template_type == chat_template_type_t::harmony) {
-                    skip_this_message = false; 
-                }
-
-                if (skip_this_message) continue;
-                    
-                if(i < messages.size() - 2)
-                    check_sum_to_compare = _calculate_checksum(content.data(), content.size(), check_sum_to_compare);
-                new_checksum = _calculate_checksum(content.data(), content.size(), new_checksum);
-            }
+            const uint64_t check_sum_to_compare = _calculate_message_checksum(messages, messages.size() - 2);
+            const uint64_t new_checksum = _calculate_message_checksum(messages, messages.size());
 
             if (checksum_ == check_sum_to_compare) {
                 checksum_ = new_checksum;
@@ -134,14 +113,30 @@ public:
 
     }
 
-    void update_checksum(json& messages) {
-        uint64_t new_checksum = 0;
-        for (size_t i = 0; i < messages.size(); ++i) {
-            const auto& msg = messages[i];
-            const std::string content = msg.value("content", "");
-            new_checksum = _calculate_checksum(content.data(), content.size(), new_checksum);
+    void update_message_checksum(json& messages) {
+        checksum_ = _calculate_message_checksum(messages, messages.size());
+    }
+
+
+    bool can_use_cache(json& messages, chat_template_type_t template_type, json& tools) {
+        (void)template_type;
+        if (messages.size() <= 2) {
+            update_message_checksum(messages);
+            update_tool_checksum(tools);
+            return false;
         }
+
+        const uint64_t check_sum_to_compare = _calculate_message_checksum(messages, messages.size() - 2);
+        const uint64_t new_checksum = _calculate_message_checksum(messages, messages.size());
+        std::vector<uint64_t> new_tool_checksums = _calculate_tool_checksums(tools);
+
+        const bool can_use_message = checksum_ == check_sum_to_compare;
+        const bool can_use_tools = tool_checksums_ == new_tool_checksums;
+
         checksum_ = new_checksum;
+        tool_checksums_ = std::move(new_tool_checksums);
+
+        return can_use_message && can_use_tools;
     }
 
     /// @brief Reset the checksum to force cache miss
@@ -149,5 +144,6 @@ public:
     ///       the next call to can_use_cache will result in a cache miss.
     void reset() {
         checksum_ = checksum_ + 1;
+        reset_tool_checksum();
     }
 };

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -921,32 +921,20 @@ void RestHandler::handle_openai_chat_completion(const json& request,
         json tools_to_insert = tools;
 
         // see if we can use prompt cache
+        bool can_use_prompt_cache = false;
         if (model != model_used_for_last_message) { // switch models will clear context
-            this->prompt_cache.update_checksum(current_messages);
+            this->prompt_cache.update_message_checksum(current_messages);
             this->prompt_cache.update_tool_checksum(tools);
             model_used_for_last_message = model;
         }
         else {
-            if (prompt_cache.can_use_cache(current_messages, auto_chat_engine->get_chat_template_type())) {
-                json cached_tools = this->prompt_cache.tool_checksum(tools);
-                if (!prompt_cache.can_use_tool_cache()) {
-                    auto_chat_engine->clear_context();
-                    this->prompt_cache.update_checksum(current_messages);
-                    this->prompt_cache.update_tool_checksum(tools);
-                }
-                else {
-                    header_print("FLM", "Use cached prompt!");
-                    // only keep the last message for insertion
-                    messages = json::array();
-                    messages.push_back(current_messages.back());
-                    tools_to_insert = cached_tools;
-                }
+            can_use_prompt_cache = prompt_cache.can_use_cache(current_messages, auto_chat_engine->get_chat_template_type(), tools);
+            if (can_use_prompt_cache) {
+                header_print("FLM", "Use cached prompt!");
             }
             else {
                 // cannot use cache, clear and re-insert all
                 auto_chat_engine->clear_context();
-                this->prompt_cache.update_checksum(current_messages);
-                this->prompt_cache.update_tool_checksum(tools);
             }
         }
 
@@ -988,12 +976,14 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                     };
                     send_response(error_response);
                     this->auto_chat_engine->clear_context();
+                    this->prompt_cache.reset();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
                 this->auto_chat_engine->clear_context();
+                this->prompt_cache.reset();
                 return;
             }
             header_print("FLM", "Start generating...");
@@ -1003,6 +993,7 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
                 this->auto_chat_engine->clear_context();
+                this->prompt_cache.reset();
                 return;
             }
             if (meta_info.stop_reason == CANCEL_DETECTED) {
@@ -1013,7 +1004,6 @@ void RestHandler::handle_openai_chat_completion(const json& request,
             ostream.finalize(meta_info);
         }
         else {
-            this->auto_chat_engine->clear_context();
             nullstream nstream;
             json response;
             std::string response_text;
@@ -1038,12 +1028,14 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                     };
                     send_response(error_response);
                     this->auto_chat_engine->clear_context();
+                    this->prompt_cache.reset();
                     return;
                 }
             } catch (const std::exception& e) {
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
                 this->auto_chat_engine->clear_context();
+                this->prompt_cache.reset();
                 return;
             }
             header_print("FLM", "Start generating...");
@@ -1053,6 +1045,7 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                 json error_response = {{"error", e.what()}};
                 send_response(error_response);
                 this->auto_chat_engine->clear_context();
+                this->prompt_cache.reset();
                 return;
             }
             // check response_text
@@ -1078,9 +1071,9 @@ void RestHandler::handle_openai_chat_completion(const json& request,
             };
             if (meta_info.stop_reason == CANCEL_DETECTED) {
                 header_print("❌ ", "Generation Cancelled!");
+                this->prompt_cache.reset();
             }
             send_response(response);
-            this->prompt_cache.reset();
         }
 
     } catch (const std::exception& e) {

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -162,6 +162,125 @@ static json normalize_template(json messages) {
 }
 
 
+///@brief Try to parse a JSON value from a string, returning the original string on failure.
+static json try_parse_json_value(const std::string& s) {
+    try {
+        return json::parse(s);
+    }
+    catch (...) {
+        return json(s);
+    }
+}
+
+///@brief Convert OpenAI-style assistant tool_calls + following tool messages into the
+/// Gemma4 chat-template format, which expects a single assistant message containing
+/// both `tool_calls` and `tool_responses` (with `{name, response}` entries).
+static json convert_tool_responses_gemma4(json messages) {
+    json converted_messages = json::array();
+
+    size_t i = 0;
+    while (i < messages.size()) {
+        const auto& msg = messages[i];
+
+        if (msg.value("role", "") != "assistant" || !msg.contains("tool_calls") ||
+            !msg.at("tool_calls").is_array() || msg.at("tool_calls").empty()) {
+            converted_messages.push_back(msg);
+            i++;
+            continue;
+        }
+
+        // Normalize tool_calls: ensure function.arguments is a JSON object (not a string).
+        json normalized_tool_calls = json::array();
+        // Map tool_call_id -> function name, for matching tool responses below.
+        std::unordered_map<std::string, std::string> id_to_name;
+        // Preserve call order so unmatched tool responses can fall back positionally.
+        std::vector<std::string> call_names_in_order;
+
+        for (const auto& tc : msg.at("tool_calls")) {
+            json new_tc = tc;
+            std::string name;
+            if (new_tc.contains("function") && new_tc["function"].is_object()) {
+                auto& fn = new_tc["function"];
+                if (fn.contains("name") && fn["name"].is_string()) {
+                    name = fn["name"].get<std::string>();
+                }
+                if (fn.contains("arguments") && fn["arguments"].is_string()) {
+                    fn["arguments"] = try_parse_json_value(fn["arguments"].get<std::string>());
+                }
+            }
+            if (new_tc.contains("id") && new_tc["id"].is_string()) {
+                id_to_name[new_tc["id"].get<std::string>()] = name;
+            }
+            call_names_in_order.push_back(name);
+            normalized_tool_calls.push_back(new_tc);
+        }
+
+        // Collect consecutive following "tool" role messages as tool_responses.
+        json tool_responses = json::array();
+        size_t j = i + 1;
+        size_t response_index = 0;
+        while (j < messages.size() && messages[j].value("role", "") == "tool") {
+            const auto& tool_msg = messages[j];
+
+            // Resolve the function name: prefer matching by tool_call_id, then by
+            // an explicit name field, then by positional order of the tool_calls.
+            std::string name;
+            if (tool_msg.contains("tool_call_id") && tool_msg["tool_call_id"].is_string()) {
+                auto it = id_to_name.find(tool_msg["tool_call_id"].get<std::string>());
+                if (it != id_to_name.end()) name = it->second;
+            }
+            if (name.empty() && tool_msg.contains("name") && tool_msg["name"].is_string()) {
+                name = tool_msg["name"].get<std::string>();
+            }
+            if (name.empty() && response_index < call_names_in_order.size()) {
+                name = call_names_in_order[response_index];
+            }
+
+            // Parse content into a JSON value if possible.
+            json response_value;
+            if (tool_msg.contains("content")) {
+                const auto& content = tool_msg.at("content");
+                if (content.is_string()) {
+                    response_value = try_parse_json_value(content.get<std::string>());
+                }
+                else {
+                    response_value = content;
+                }
+            }
+            else {
+                response_value = nullptr;
+            }
+
+            tool_responses.push_back({
+                {"name", name},
+                {"response", response_value},
+            });
+
+            response_index++;
+            j++;
+        }
+
+        json merged = {
+            {"role", "assistant"},
+            {"tool_calls", normalized_tool_calls},
+        };
+        if (!tool_responses.empty()) {
+            merged["tool_responses"] = tool_responses;
+        }
+        if (msg.contains("content") && !msg.at("content").is_null()) {
+            merged["content"] = msg.at("content");
+        }
+        if (msg.contains("reasoning_content") && !msg.at("reasoning_content").is_null()) {
+            merged["reasoning_content"] = msg.at("reasoning_content");
+        }
+
+        converted_messages.push_back(merged);
+        i = j;
+    }
+
+    return converted_messages;
+}
+
 ///@brief RestHandler constructor
 ///@param models the model list
 ///@param downloader the downloader
@@ -916,9 +1035,6 @@ void RestHandler::handle_openai_chat_completion(const json& request,
 
         current_messages = normalize_messages(current_messages);
         current_messages = normalize_template(current_messages);
-        
-        json messages = current_messages;
-        json tools_to_insert = tools;
 
         // see if we can use prompt cache
         bool can_use_prompt_cache = false;
@@ -938,10 +1054,14 @@ void RestHandler::handle_openai_chat_completion(const json& request,
             }
         }
 
+        if (model.starts_with("gemma4-it")) {
+            current_messages = convert_tool_responses_gemma4(current_messages);
+        }
+
         chat_meta_info_t meta_info;
         lm_uniform_input_t uniformed_input;
-        uniformed_input.messages = messages;
-        uniformed_input.tools = tools_to_insert;
+        uniformed_input.messages = current_messages;
+        uniformed_input.tools = tools;
         meta_info.load_duration = (uint64_t)time_utils::duration_ns(load_start_time, load_end_time).first;
         meta_info.max_prefill_len = this->prefill_chunk_len;
         if (stream){


### PR DESCRIPTION
## Overview
This PR refactors the prompt caching mechanism to improve robustness and ensure strict adherence to model chat templates during multi-turn conversations. We are shifting from message-level manipulation to a safer, token-level delta approach.

## Logic Update
### Previous Implementation:

- Computed a checksum of the incoming messages.

- Cache Hit: Manually deleted the old message from the list.

- Cache Miss: Cleared the context.

**Issue:** Manipulating the message list directly before templating could lead to fragmented or incorrectly formatted conversation histories.

### Updated Implementation:

- Computes a checksum of the incoming messages.

- Cache Hit: Retains the existing context and processes the complete original message history.

- Cache Miss: Same as previous.

**Consistent Templating:** We now always apply the chat template to the complete, unbroken message history from the client. This guarantees the continuous string is formatting-correct.

**Token-Level Diffing:** Instead of dropping old text messages, we tokenize the fully templated string and compare the resulting token IDs with the cached token IDs from the previous turn. We then strip the overlapping old IDs and retain only the newly generated token IDs for the prefill phase.