### PR TITLE
feat and fix: sleep idle seconds for server and parse error

### DIFF
--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -131,7 +131,11 @@ void AutoModel::_shared_load_model(std::string model_path, json model_info, int 
     if (default_context_length != -1) {
         this->MAX_L = default_context_length;
     } else {
-        this->MAX_L = model_info["default_context_length"];
+        if (model_info.contains("default_context_length") && model_info["default_context_length"].is_number_integer()) {
+            this->MAX_L = model_info["default_context_length"].get<int>();
+        } else {
+            this->MAX_L = 2048;
+        }
     }
     
     this->is_model_loaded = true;

--- a/src/include/program_args.hpp
+++ b/src/include/program_args.hpp
@@ -20,6 +20,7 @@ struct program_args_t {
     bool json_output = false;
     int ctx_length = -1; // let model decide
     int prefill_chunk_len = -1; // let model decide
+    int sleep_idle_seconds = -1; // if >0, unload models after this many idle seconds
 
     // handling input file
     std::string input_file_name = "";

--- a/src/include/utils/vm_args.hpp
+++ b/src/include/utils/vm_args.hpp
@@ -89,6 +89,8 @@ bool parse_options(int argc, char *argv[], program_args_t& parsed_args) {
              "Set context length")
             ("prefill-chunk-len,pcl", po::value<int>(&parsed_args.prefill_chunk_len)->default_value(-1),
              "Set prefill chunk length")
+            ("sleep-idle-seconds,sis", po::value<int>(&parsed_args.sleep_idle_seconds)->default_value(-1),
+             "Sleep after N idle seconds (-1 disables)")
             ("img-pre-resize,r", po::value<int>(&parsed_args.img_pre_resize)->default_value(2),
              "Pre-resize the image, 0: original size, 1: height = 480, 2: height = 720, 3: height = 1080, 4: height = 1440")
             ("socket,s", po::value<size_t>(&parsed_args.max_socket_connections)->default_value(10),
@@ -190,6 +192,17 @@ bool parse_options(int argc, char *argv[], program_args_t& parsed_args) {
                 std::cerr << "Error: The cors option is only supported with the serve command! " << std::endl;
                 return false;
             }
+            if (!vm["sleep-idle-seconds"].defaulted())
+            {
+                std::cerr << "Error: The sleep-idle-seconds option is only supported with the serve command! " << std::endl;
+                return false;
+            }
+        }
+
+        if (parsed_args.sleep_idle_seconds == 0 || parsed_args.sleep_idle_seconds < -1)
+        {
+            std::cerr << "Error: sleep-idle-seconds must be -1 (disabled) or a positive integer." << std::endl;
+            return false;
         }
 
         // Handle all options

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -500,16 +500,23 @@ void RestHandler::on_model_request_start() {
     if (!is_sleep_enabled()) {
         return;
     }
+    std::unique_lock<std::mutex> lock(sleep_mutex);
+    sleep_cv.wait(lock, [&]() {
+        return !sleep_transitioning;
+    });
     active_model_requests.fetch_add(1);
-    note_activity();
+    last_activity = std::chrono::steady_clock::now();
+    sleep_cv.notify_all();
 }
 
 void RestHandler::on_model_request_end() {
     if (!is_sleep_enabled()) {
         return;
     }
+    std::lock_guard<std::mutex> lock(sleep_mutex);
     active_model_requests.fetch_sub(1);
-    note_activity();
+    last_activity = std::chrono::steady_clock::now();
+    sleep_cv.notify_all();
 }
 
 void RestHandler::note_activity() {
@@ -565,13 +572,17 @@ void RestHandler::idle_monitor_loop() {
         if (woke) {
             continue;
         }
-        if (active_model_requests.load() > 0) {
+        if (active_model_requests.load() > 0 || sleep_transitioning) {
             continue;
         }
 
-        sleeping = true;
+        sleep_transitioning = true;
         lock.unlock();
         enter_sleep();
+        lock.lock();
+        sleeping = true;
+        sleep_transitioning = false;
+        sleep_cv.notify_all();
     }
 }
 
@@ -991,7 +1002,13 @@ void RestHandler::handle_embeddings(const json& request,
         json response;
         if (this->embed) {
             if (!ensure_embed_model_ready()) {
-                json error_response = {{"error", "Embedding model is not available"}};
+                json error_response = {
+                    {"error", {
+                        {"code", 503},
+                        {"type", "service_unavailable"},
+                        {"message", "Embedding model is not available"}
+                    }}
+                };
                 send_response(error_response);
                 return;
             }
@@ -1419,11 +1436,7 @@ void RestHandler::handle_openai_audio_transcriptions(const json& request,
         json response;
         if (this->asr) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
-            if (!ensure_asr_model_ready()) {
-                json error_response = {{"error", "ASR model is not available"}};
-                send_response(error_response);
-                return;
-            }
+            ensure_asr_model_ready();
             this->whisper_engine->load_audio(audio_raw);
             header_print("FLM", "Transforming audio to text...");
             // Show text
@@ -1454,7 +1467,15 @@ void RestHandler::handle_openai_audio_transcriptions(const json& request,
             };
         }
         else {
-            header_print("Warning", "No asr model loaded, cannot load audio file");
+            json error_response = {
+                {"error", {
+                    {"code", 503},
+                    {"type", "service_unavailable"},
+                    {"message", "ASR model is not available"}
+                }}
+            };
+            send_response(error_response);
+            return;
         }
         send_response(response);
         //this->whisper_engine->clear_context();

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -399,7 +399,11 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
         }
         
         if (this->prefill_chunk_len == -1) {
-            this->prefill_chunk_len = model_info["max_prefill_len"].get<int>();;
+            if (model_info.contains("max_prefill_len") && model_info["max_prefill_len"].is_number_integer()) {
+                this->prefill_chunk_len = model_info["max_prefill_len"].get<int>();
+            } else {
+                this->prefill_chunk_len = 4096;
+            }
         }
         current_model_tag = ensure_tag;
     }

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -475,9 +475,7 @@ bool RestHandler::ensure_asr_model_ready() {
     if (!this->asr) {
         return false;
     }
-    if (whisper_engine == nullptr) {
-        ensure_asr_model_loaded(asr_model_tag);
-    }
+    ensure_asr_model_loaded(asr_model_tag);
     {
         std::lock_guard<std::mutex> lock(sleep_mutex);
         if (sleeping) {
@@ -498,9 +496,7 @@ bool RestHandler::ensure_embed_model_ready() {
     if (!this->embed) {
         return false;
     }
-    if (auto_embedding_engine == nullptr) {
-        ensure_embed_model_loaded(embed_model_tag);
-    }
+    ensure_embed_model_loaded(embed_model_tag);
     {
         std::lock_guard<std::mutex> lock(sleep_mutex);
         if (sleeping) {
@@ -581,9 +577,18 @@ void RestHandler::idle_monitor_loop() {
             continue;
         }
 
-        auto deadline = last_activity + idle_timeout;
+        if (active_model_requests.load() > 0) {
+            sleep_cv.wait(lock, [&]() {
+                return stop_idle_monitoring.load() || sleeping || active_model_requests.load() == 0;
+            });
+            continue;
+        }
+
+        auto activity_snapshot = last_activity;
+        auto deadline = activity_snapshot + idle_timeout;
         bool woke = sleep_cv.wait_until(lock, deadline, [&]() {
-            return stop_idle_monitoring.load() || sleeping || active_model_requests.load() > 0;
+            return stop_idle_monitoring.load() || sleeping ||
+                active_model_requests.load() > 0 || last_activity != activity_snapshot;
         });
 
         if (stop_idle_monitoring.load()) {
@@ -592,7 +597,7 @@ void RestHandler::idle_monitor_loop() {
         if (woke) {
             continue;
         }
-        if (active_model_requests.load() > 0 || sleep_transitioning) {
+        if (active_model_requests.load() > 0 || sleep_transitioning || last_activity != activity_snapshot) {
             continue;
         }
 

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -417,11 +417,11 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
 
 ///@brief Ensure the asr model is loaded
 ///@param model_tag the model tag
-void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
+bool RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
     std::lock_guard<std::mutex> model_lock(model_mutex);
     if (whisper_engine != nullptr) {
-        return;
+        return true;
     }
     std::string ensure_tag = model_tag;
     if (!downloader.is_model_downloaded(ensure_tag)) {
@@ -435,20 +435,22 @@ void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
     }
     catch (const std::exception& e) {
         header_print("ERROR", "Failed to load ASR model: " + std::string(e.what()));
-        exit(EXIT_FAILURE);
+        this->whisper_engine.reset();
+        return false;
     }
+    return true;
 #else
-    throw std::runtime_error("ASR models are not supported in this build");
+    return false;
 #endif
 }
 
 ///@brief Ensure the embed model is loaded
 ///@param model_tag the model tag
-void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
+bool RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
     std::lock_guard<std::mutex> model_lock(model_mutex);
     if (auto_embedding_engine != nullptr) {
-        return;
+        return true;
     }
     std::string ensure_tag = model_tag;
     if (!this->downloader.is_model_downloaded(ensure_tag)) {
@@ -463,10 +465,12 @@ void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
     }
     catch (const std::exception& e) {
         header_print("ERROR", "Failed to load embedding model: " + std::string(e.what()));
-        exit(EXIT_FAILURE);
+        this->auto_embedding_engine.reset();
+        return false;
     }
+    return true;
 #else
-    throw std::runtime_error("Embedding models are not supported in this build");
+    return false;
 #endif
 }
 
@@ -475,7 +479,9 @@ bool RestHandler::ensure_asr_model_ready() {
     if (!this->asr) {
         return false;
     }
-    ensure_asr_model_loaded(asr_model_tag);
+    if (!ensure_asr_model_loaded(asr_model_tag)) {
+        return false;
+    }
     {
         std::lock_guard<std::mutex> lock(sleep_mutex);
         if (sleeping) {
@@ -496,7 +502,9 @@ bool RestHandler::ensure_embed_model_ready() {
     if (!this->embed) {
         return false;
     }
-    ensure_embed_model_loaded(embed_model_tag);
+    if (!ensure_embed_model_loaded(embed_model_tag)) {
+        return false;
+    }
     {
         std::lock_guard<std::mutex> lock(sleep_mutex);
         if (sleeping) {
@@ -1064,7 +1072,15 @@ void RestHandler::handle_embeddings(const json& request,
             };
         }
         else {
-            header_print("Warning", "No embedding model loaded");
+            json error_response = {
+                {"error", {
+                    {"code", 503},
+                    {"type", "service_unavailable"},
+                    {"message", "Embedding model is not available"}
+                }}
+            };
+            send_response(error_response);
+            return;
         }
         send_response(response);
     }
@@ -1462,35 +1478,39 @@ void RestHandler::handle_openai_audio_transcriptions(const json& request,
         json response;
         if (this->asr) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
-            ensure_asr_model_ready();
+            if (!ensure_asr_model_ready()) {
+                json error_response = {
+                    {"error", {
+                        {"code", 503},
+                        {"type", "service_unavailable"},
+                        {"message", "ASR model is not available"}
+                    }}
+                };
+                send_response(error_response);
+                return;
+            }
             this->whisper_engine->load_audio(audio_raw);
             header_print("FLM", "Transforming audio to text...");
-            // Show text
             std::cout << "Audio content: " << std::flush;
             std::pair<std::string, std::string> audio_result = this->whisper_engine->generate(Whisper::whisper_task_type_t::e_transcribe, true, false, std::cout);
             std::string audio_context = audio_result.first;
             std::cout << std::endl;
-#else
-            throw std::runtime_error("ASR models are not supported in this build");
-            std::string audio_context;
-#endif
 
             response = {
                 {"model", model},
                 {"text", audio_context}
-                //{"usage", {
-                //    {"type", "tokens"},
-                //    {"input_tokens", 0},
-                //    {"input_tokens_details", json::array({
-                //        {
-                //            {"text_tokens", 0},
-                //            {"audio_tokens", 0}
-                //        }
-                //    })},
-                //    {"output_tokens", 0},
-                //    {"total_tokens", 0}
-                //}}
             };
+#else
+            json error_response = {
+                {"error", {
+                    {"code", 503},
+                    {"type", "service_unavailable"},
+                    {"message", "ASR models are not supported in this build"}
+                }}
+            };
+            send_response(error_response);
+            return;
+#endif
         }
         else {
             json error_response = {

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -351,16 +351,24 @@ RestHandler::~RestHandler() {
 bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
     note_activity();
 
-    bool was_sleeping = false;
+    bool must_wake = false;
     {
-        std::lock_guard<std::mutex> lock(sleep_mutex);
-        was_sleeping = sleeping;
+        std::unique_lock<std::mutex> lock(sleep_mutex);
+        if (sleeping) {
+            sleep_cv.wait(lock, [&]() {
+                return !sleep_transitioning;
+            });
+            if (sleeping) {
+                sleep_transitioning = true;
+                must_wake = true;
+            }
+        }
     }
 
     std::lock_guard<std::mutex> model_lock(model_mutex);
 
     std::string ensure_tag = model_tag;
-    if (was_sleeping || current_model_tag != ensure_tag) {
+    if (must_wake || current_model_tag != ensure_tag || auto_chat_engine == nullptr) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         if (auto_chat_engine != nullptr) {
             auto_chat_engine.reset();
@@ -382,6 +390,11 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
             this->npu_device_inst.reset();
             this->npu_device_inst = xrt::device(0);
             this->current_model_tag = "model-faker";
+            if (must_wake) {
+                std::lock_guard<std::mutex> lock(sleep_mutex);
+                sleep_transitioning = false;
+                sleep_cv.notify_all();
+            }
             return false;
         }
         
@@ -391,9 +404,10 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
         current_model_tag = ensure_tag;
     }
 
-    if (was_sleeping) {
+    if (must_wake) {
         std::lock_guard<std::mutex> lock(sleep_mutex);
         sleeping = false;
+        sleep_transitioning = false;
         last_activity = std::chrono::steady_clock::now();
         sleep_cv.notify_all();
         header_print("FLM", "Woke from idle sleep");
@@ -406,6 +420,9 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
 void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
     std::lock_guard<std::mutex> model_lock(model_mutex);
+    if (whisper_engine != nullptr) {
+        return;
+    }
     std::string ensure_tag = model_tag;
     if (!downloader.is_model_downloaded(ensure_tag)) {
         downloader.pull_model(ensure_tag);
@@ -430,6 +447,9 @@ void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
 void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
     std::lock_guard<std::mutex> model_lock(model_mutex);
+    if (auto_embedding_engine != nullptr) {
+        return;
+    }
     std::string ensure_tag = model_tag;
     if (!this->downloader.is_model_downloaded(ensure_tag)) {
         this->downloader.pull_model(ensure_tag);

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -290,8 +290,10 @@ static json convert_tool_responses_gemma4(json messages) {
 
 ///@return the rest handler
 RestHandler::RestHandler(model_list& models, ModelDownloader& downloader, program_args_t& args)
-    : supported_models(models), downloader(downloader), default_model_tag(args.model_tag), current_model_tag(""), asr(args.asr), embed(args.embed), img_pre_resize(args.img_pre_resize), preemption(args.preemption){
+    : supported_models(models), downloader(downloader), default_model_tag(args.model_tag), current_model_tag(""), asr(args.asr), embed(args.embed), img_pre_resize(args.img_pre_resize), preemption(args.preemption), sleep_idle_seconds(args.sleep_idle_seconds) {
     this->npu_device_inst = xrt::device(0);
+    this->asr_model_tag = "whisper-v3:turbo";
+    this->embed_model_tag = "embed-gemma:300m";
 
     if (args.ctx_length != -1) {
         this->ctx_length = args.ctx_length >= 512 ? args.ctx_length : 512;
@@ -308,12 +310,10 @@ RestHandler::RestHandler(model_list& models, ModelDownloader& downloader, progra
     // Initialize chat bot with default model
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
     if (this->asr) {
-        std::string whisper_tag = "whisper-v3:turbo";
-        ensure_asr_model_loaded(whisper_tag);
+        ensure_asr_model_loaded(asr_model_tag);
     }
     if (this->embed) {
-        std::string embed_tag = "embed-gemma:300m";
-        ensure_embed_model_loaded(embed_tag);
+        ensure_embed_model_loaded(embed_model_tag);
     }
 #else
     if (this->asr) {
@@ -337,17 +337,30 @@ RestHandler::RestHandler(model_list& models, ModelDownloader& downloader, progra
         this->current_model_tag = "model-faker";
     }
     this->prompt_cache = PromptCache();
+    start_idle_monitor();
 }
 
 ///@brief RestHandler destructor
 ///@return the rest handler
-RestHandler::~RestHandler() = default;
+RestHandler::~RestHandler() {
+    stop_idle_monitor();
+}
 
 ///@brief Ensure the model is loaded
 ///@param model_tag the model tag
 bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
+    note_activity();
+
+    bool was_sleeping = false;
+    {
+        std::lock_guard<std::mutex> lock(sleep_mutex);
+        was_sleeping = sleeping;
+    }
+
+    std::lock_guard<std::mutex> model_lock(model_mutex);
+
     std::string ensure_tag = model_tag;
-    if (current_model_tag != ensure_tag) {
+    if (was_sleeping || current_model_tag != ensure_tag) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
         if (auto_chat_engine != nullptr) {
             auto_chat_engine.reset();
@@ -377,6 +390,14 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
         }
         current_model_tag = ensure_tag;
     }
+
+    if (was_sleeping) {
+        std::lock_guard<std::mutex> lock(sleep_mutex);
+        sleeping = false;
+        last_activity = std::chrono::steady_clock::now();
+        sleep_cv.notify_all();
+        header_print("FLM", "Woke from idle sleep");
+    }
     return true;
 }
 
@@ -384,6 +405,7 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
 ///@param model_tag the model tag
 void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+    std::lock_guard<std::mutex> model_lock(model_mutex);
     std::string ensure_tag = model_tag;
     if (!downloader.is_model_downloaded(ensure_tag)) {
         downloader.pull_model(ensure_tag);
@@ -407,6 +429,7 @@ void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
 ///@param model_tag the model tag
 void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+    std::lock_guard<std::mutex> model_lock(model_mutex);
     std::string ensure_tag = model_tag;
     if (!this->downloader.is_model_downloaded(ensure_tag)) {
         this->downloader.pull_model(ensure_tag);
@@ -425,6 +448,152 @@ void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
 #else
     throw std::runtime_error("Embedding models are not supported in this build");
 #endif
+}
+
+bool RestHandler::ensure_asr_model_ready() {
+#ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+    if (!this->asr) {
+        return false;
+    }
+    if (whisper_engine == nullptr) {
+        ensure_asr_model_loaded(asr_model_tag);
+    }
+    {
+        std::lock_guard<std::mutex> lock(sleep_mutex);
+        if (sleeping) {
+            sleeping = false;
+            last_activity = std::chrono::steady_clock::now();
+            sleep_cv.notify_all();
+            header_print("FLM", "Woke from idle sleep");
+        }
+    }
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool RestHandler::ensure_embed_model_ready() {
+#ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+    if (!this->embed) {
+        return false;
+    }
+    if (auto_embedding_engine == nullptr) {
+        ensure_embed_model_loaded(embed_model_tag);
+    }
+    {
+        std::lock_guard<std::mutex> lock(sleep_mutex);
+        if (sleeping) {
+            sleeping = false;
+            last_activity = std::chrono::steady_clock::now();
+            sleep_cv.notify_all();
+            header_print("FLM", "Woke from idle sleep");
+        }
+    }
+    return true;
+#else
+    return false;
+#endif
+}
+
+void RestHandler::on_model_request_start() {
+    if (!is_sleep_enabled()) {
+        return;
+    }
+    active_model_requests.fetch_add(1);
+    note_activity();
+}
+
+void RestHandler::on_model_request_end() {
+    if (!is_sleep_enabled()) {
+        return;
+    }
+    active_model_requests.fetch_sub(1);
+    note_activity();
+}
+
+void RestHandler::note_activity() {
+    if (!is_sleep_enabled()) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(sleep_mutex);
+    last_activity = std::chrono::steady_clock::now();
+    sleep_cv.notify_all();
+}
+
+void RestHandler::start_idle_monitor() {
+    if (!is_sleep_enabled()) {
+        return;
+    }
+    last_activity = std::chrono::steady_clock::now();
+    idle_monitor_thread = std::thread([this]() {
+        idle_monitor_loop();
+    });
+}
+
+void RestHandler::stop_idle_monitor() {
+    if (!is_sleep_enabled()) {
+        return;
+    }
+    stop_idle_monitoring.store(true);
+    sleep_cv.notify_all();
+    if (idle_monitor_thread.joinable()) {
+        idle_monitor_thread.join();
+    }
+}
+
+void RestHandler::idle_monitor_loop() {
+    const auto idle_timeout = std::chrono::seconds(sleep_idle_seconds);
+
+    while (!stop_idle_monitoring.load()) {
+        std::unique_lock<std::mutex> lock(sleep_mutex);
+        if (sleeping) {
+            sleep_cv.wait(lock, [&]() {
+                return stop_idle_monitoring.load() || !sleeping;
+            });
+            continue;
+        }
+
+        auto deadline = last_activity + idle_timeout;
+        bool woke = sleep_cv.wait_until(lock, deadline, [&]() {
+            return stop_idle_monitoring.load() || sleeping || active_model_requests.load() > 0;
+        });
+
+        if (stop_idle_monitoring.load()) {
+            return;
+        }
+        if (woke) {
+            continue;
+        }
+        if (active_model_requests.load() > 0) {
+            continue;
+        }
+
+        sleeping = true;
+        lock.unlock();
+        enter_sleep();
+    }
+}
+
+void RestHandler::enter_sleep() {
+    std::lock_guard<std::mutex> model_lock(model_mutex);
+    if (auto_chat_engine != nullptr) {
+        auto_chat_engine.reset();
+    }
+#ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+    if (whisper_engine != nullptr) {
+        whisper_engine.reset();
+    }
+    if (auto_embedding_engine != nullptr) {
+        auto_embedding_engine.reset();
+    }
+#endif
+    prompt_cache.reset();
+    header_print("FLM", "Server entered idle sleep");
+}
+
+bool RestHandler::is_sleep_enabled() const {
+    return sleep_idle_seconds > 0;
 }
 
 ///@brief Configure chat engine parameters from options and request
@@ -562,6 +731,10 @@ void RestHandler::handle_generate(const json& request,
                                  std::function<void(const json&)> send_response,
                                  StreamResponseCallback send_streaming_response,
                                  std::shared_ptr<CancellationToken> cancellation_token) {
+    on_model_request_start();
+    auto request_scope = std::unique_ptr<void, std::function<void(void*)>>(
+        reinterpret_cast<void*>(1),
+        [&](void*) { on_model_request_end(); });
     try {
         std::string prompt = request["prompt"];
         bool stream = request.value("stream", true);
@@ -676,6 +849,10 @@ void RestHandler::handle_chat(const json& request,
                              std::function<void(const json&)> send_response,
                              StreamResponseCallback send_streaming_response,
                              std::shared_ptr<CancellationToken> cancellation_token) {
+    on_model_request_start();
+    auto request_scope = std::unique_ptr<void, std::function<void(void*)>>(
+        reinterpret_cast<void*>(1),
+        [&](void*) { on_model_request_end(); });
     try {
         nlohmann::ordered_json messages = request["messages"];
         bool stream = request.value("stream", false);
@@ -794,6 +971,10 @@ void RestHandler::handle_chat(const json& request,
 void RestHandler::handle_embeddings(const json& request,
                                    std::function<void(const json&)> send_response,
                                    StreamResponseCallback send_streaming_response) {
+    on_model_request_start();
+    auto request_scope = std::unique_ptr<void, std::function<void(void*)>>(
+        reinterpret_cast<void*>(1),
+        [&](void*) { on_model_request_end(); });
     try {
         std::string model = request["model"];
         std::vector<std::string> inputs;
@@ -809,6 +990,11 @@ void RestHandler::handle_embeddings(const json& request,
 
         json response;
         if (this->embed) {
+            if (!ensure_embed_model_ready()) {
+                json error_response = {{"error", "Embedding model is not available"}};
+                send_response(error_response);
+                return;
+            }
             json embedding_data = json::array();
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
             for (size_t i = 0; i < inputs.size(); ++i) {
@@ -1013,6 +1199,10 @@ void RestHandler::handle_openai_chat_completion(const json& request,
                                                std::function<void(const json&)> send_response,
                                                StreamResponseCallback send_streaming_response,
                                                std::shared_ptr<CancellationToken> cancellation_token) {
+    on_model_request_start();
+    auto request_scope = std::unique_ptr<void, std::function<void(void*)>>(
+        reinterpret_cast<void*>(1),
+        [&](void*) { on_model_request_end(); });
     static std::string model_used_for_last_message = "model-faker";
     try {
         // Extract OpenAI-style parameters
@@ -1217,6 +1407,10 @@ void RestHandler::handle_openai_audio_transcriptions(const json& request,
                                         std::function<void(const json&)> send_response,
                                         StreamResponseCallback send_streaming_response,
                                         std::shared_ptr<CancellationToken> cancellation_token) {
+    on_model_request_start();
+    auto request_scope = std::unique_ptr<void, std::function<void(void*)>>(
+        reinterpret_cast<void*>(1),
+        [&](void*) { on_model_request_end(); });
     try {
         std::string model = request["model"];
         std::string file_content = request["file"].get<std::string>();
@@ -1225,6 +1419,11 @@ void RestHandler::handle_openai_audio_transcriptions(const json& request,
         json response;
         if (this->asr) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
+            if (!ensure_asr_model_ready()) {
+                json error_response = {{"error", "ASR model is not available"}};
+                send_response(error_response);
+                return;
+            }
             this->whisper_engine->load_audio(audio_raw);
             header_print("FLM", "Transforming audio to text...");
             // Show text
@@ -1280,6 +1479,10 @@ void RestHandler::handle_openai_completion(const json& request,
     std::function<void(const json&)> send_response,
     StreamResponseCallback send_streaming_response,
     std::shared_ptr<CancellationToken> cancellation_token) {
+    on_model_request_start();
+    auto request_scope = std::unique_ptr<void, std::function<void(void*)>>(
+        reinterpret_cast<void*>(1),
+        [&](void*) { on_model_request_end(); });
     try {
         // Extract OpenAI-style parameters
         std::string prompt = request["prompt"];

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -548,6 +548,7 @@ void RestHandler::start_idle_monitor() {
     if (!is_sleep_enabled()) {
         return;
     }
+    stop_idle_monitoring.store(false);
     last_activity = std::chrono::steady_clock::now();
     idle_monitor_thread = std::thread([this]() {
         idle_monitor_loop();

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -367,22 +367,39 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
 
     std::lock_guard<std::mutex> model_lock(model_mutex);
 
+    auto clear_wake_transition = [&]() {
+        if (must_wake) {
+            std::lock_guard<std::mutex> lock(sleep_mutex);
+            sleep_transitioning = false;
+            sleep_cv.notify_all();
+        }
+    };
+
     std::string ensure_tag = model_tag;
     if (must_wake || current_model_tag != ensure_tag || auto_chat_engine == nullptr) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        if (auto_chat_engine != nullptr) {
-            auto_chat_engine.reset();
-        }
-        std::pair<std::string, std::unique_ptr<AutoModel>> auto_model = get_auto_model(ensure_tag, this->supported_models, &this->npu_device_inst);
-        auto_chat_engine = std::move(auto_model.second);
-        ensure_tag = auto_model.first;
-        if (!downloader.is_model_downloaded(ensure_tag)) {
-            downloader.pull_model(ensure_tag);
-        }
-        auto [new_ensure_tag, model_info] = supported_models.get_model_info(ensure_tag);
-        auto_chat_engine->configure_parameter("img_pre_resize", this->img_pre_resize);
         try {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            if (auto_chat_engine != nullptr) {
+                auto_chat_engine.reset();
+            }
+            std::pair<std::string, std::unique_ptr<AutoModel>> auto_model = get_auto_model(ensure_tag, this->supported_models, &this->npu_device_inst);
+            auto_chat_engine = std::move(auto_model.second);
+            ensure_tag = auto_model.first;
+            if (!downloader.is_model_downloaded(ensure_tag)) {
+                downloader.pull_model(ensure_tag);
+            }
+            auto [new_ensure_tag, model_info] = supported_models.get_model_info(ensure_tag);
+            auto_chat_engine->configure_parameter("img_pre_resize", this->img_pre_resize);
             auto_chat_engine->load_model(supported_models.get_model_path(new_ensure_tag), model_info, ctx_length, preemption);
+
+            if (this->prefill_chunk_len == -1) {
+                if (model_info.contains("max_prefill_len") && model_info["max_prefill_len"].is_number_integer()) {
+                    this->prefill_chunk_len = model_info["max_prefill_len"].get<int>();
+                } else {
+                    this->prefill_chunk_len = 4096;
+                }
+            }
+            current_model_tag = ensure_tag;
         }
         catch (const std::exception& e) {
             header_print("ERROR", "Failed to load model: " + std::string(e.what()));
@@ -390,22 +407,18 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
             this->npu_device_inst.reset();
             this->npu_device_inst = xrt::device(0);
             this->current_model_tag = "model-faker";
-            if (must_wake) {
-                std::lock_guard<std::mutex> lock(sleep_mutex);
-                sleep_transitioning = false;
-                sleep_cv.notify_all();
-            }
+            clear_wake_transition();
             return false;
         }
-        
-        if (this->prefill_chunk_len == -1) {
-            if (model_info.contains("max_prefill_len") && model_info["max_prefill_len"].is_number_integer()) {
-                this->prefill_chunk_len = model_info["max_prefill_len"].get<int>();
-            } else {
-                this->prefill_chunk_len = 4096;
-            }
+        catch (...) {
+            header_print("ERROR", "Failed to load model: unknown exception");
+            this->auto_chat_engine.reset();
+            this->npu_device_inst.reset();
+            this->npu_device_inst = xrt::device(0);
+            this->current_model_tag = "model-faker";
+            clear_wake_transition();
+            return false;
         }
-        current_model_tag = ensure_tag;
     }
 
     if (must_wake) {

--- a/src/server/rest_handler.hpp
+++ b/src/server/rest_handler.hpp
@@ -161,5 +161,6 @@ private:
     std::condition_variable sleep_cv;
     std::chrono::steady_clock::time_point last_activity;
     bool sleeping = false;
+    bool sleep_transitioning = false;
     std::mutex model_mutex;
 };

--- a/src/server/rest_handler.hpp
+++ b/src/server/rest_handler.hpp
@@ -114,8 +114,8 @@ public:
 
 private:
     bool ensure_model_loaded(const std::string& model_tag);
-    void ensure_asr_model_loaded(const std::string& model_tag);
-    void ensure_embed_model_loaded(const std::string& model_tag);
+    bool ensure_asr_model_loaded(const std::string& model_tag);
+    bool ensure_embed_model_loaded(const std::string& model_tag);
     bool ensure_asr_model_ready();
     bool ensure_embed_model_ready();
     void on_model_request_start();

--- a/src/server/rest_handler.hpp
+++ b/src/server/rest_handler.hpp
@@ -22,6 +22,11 @@
 #include <string>
 #include <memory>
 #include <functional>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
 #include "prompt_cache.hpp"
 
 using json = nlohmann::ordered_json;
@@ -111,6 +116,16 @@ private:
     bool ensure_model_loaded(const std::string& model_tag);
     void ensure_asr_model_loaded(const std::string& model_tag);
     void ensure_embed_model_loaded(const std::string& model_tag);
+    bool ensure_asr_model_ready();
+    bool ensure_embed_model_ready();
+    void on_model_request_start();
+    void on_model_request_end();
+    void note_activity();
+    void start_idle_monitor();
+    void stop_idle_monitor();
+    void idle_monitor_loop();
+    void enter_sleep();
+    bool is_sleep_enabled() const;
     void configure_chat_engine_parameters(const json& options, const json& request);
     json build_nstream_response(std::string response_text);
 
@@ -125,6 +140,8 @@ private:
     ModelDownloader& downloader;
     std::string current_model_tag;
     std::string default_model_tag;
+    std::string asr_model_tag;
+    std::string embed_model_tag;
     bool asr;
     bool embed;
     int prefill_chunk_len;
@@ -135,4 +152,14 @@ private:
     std::string last_question;
     bool preemption;
     PromptCache prompt_cache;
+
+    int sleep_idle_seconds;
+    std::atomic<int> active_model_requests{0};
+    std::atomic<bool> stop_idle_monitoring{false};
+    std::thread idle_monitor_thread;
+    std::mutex sleep_mutex;
+    std::condition_variable sleep_cv;
+    std::chrono::steady_clock::time_point last_activity;
+    bool sleeping = false;
+    std::mutex model_mutex;
 };

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -730,18 +730,24 @@ bool WebServer::handle_request(http::request<http::string_body>& req,
             auto& response_ref = *res_ptr;
             http::status status = http::status::ok;
 
-            if (response_data.contains("error") &&
-                response_data["error"].contains("code"))
+            if (response_data.contains("error"))
             {
-                int code = response_data["error"]["code"].get<int>();
+                if (response_data["error"].is_object() && response_data["error"].contains("code"))
+                {
+                    int code = response_data["error"]["code"].get<int>();
 
-                if (code == 400) {
-                    status = http::status::bad_request;
-                } else if (code == 503) {
-                    status = http::status::service_unavailable;
-                } else if (code == 501) {
-                    status = http::status::not_implemented;
-                } else if (code >= 500) {
+                    if (code == 400) {
+                        status = http::status::bad_request;
+                    } else if (code == 503) {
+                        status = http::status::service_unavailable;
+                    } else if (code == 501) {
+                        status = http::status::not_implemented;
+                    } else if (code >= 500) {
+                        status = http::status::internal_server_error;
+                    }
+                }
+                else if (response_data["error"].is_string())
+                {
                     status = http::status::internal_server_error;
                 }
             }

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -737,10 +737,13 @@ bool WebServer::handle_request(http::request<http::string_body>& req,
 
                 if (code == 400) {
                     status = http::status::bad_request;
+                } else if (code == 503) {
+                    status = http::status::service_unavailable;
+                } else if (code == 501) {
+                    status = http::status::not_implemented;
+                } else if (code >= 500) {
+                    status = http::status::internal_server_error;
                 }
-                //else if () {
-
-                //}
             }
 
             response_ref.result(status);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -732,7 +732,7 @@ bool WebServer::handle_request(http::request<http::string_body>& req,
 
             if (response_data.contains("error"))
             {
-                if (response_data["error"].is_object() && response_data["error"].contains("code"))
+                if (response_data["error"].is_object() && response_data["error"].contains("code") && response_data["error"]["code"].is_number_integer())
                 {
                     int code = response_data["error"]["code"].get<int>();
 


### PR DESCRIPTION
Fixes #562 

## Summary

This PR addresses a JSON parsing crash during model initialization and introduces an automated idle-sleep feature to optimize system memory usage when the server is not actively processing requests.

## Changes

### 1. Bug Fixes
I tried running the server and got:
```
./build/flm serve llama3.2:1b
[FLM]  Using environment-specified port: 52625
[FLM]  Loading model: /home/oisenhart/.config/flm/models/Llama-3.2-1B-NPU2
Error: [json.exception.type_error.302] type must be number, but is null
```

* **JSON Type Error Fix:** Added explicit `.contains()` and `.is_number_integer()` validation checks for `default_context_length` and `max_prefill_len` within `automodel.cpp` and `rest_handler.cpp`. This resolves the `[json.exception.type_error.302]` crash occurring when these optional fields are missing or read as `null` (e.g., when serving `llama3.2:1b`).

### 2. New Feature (Sleep idle seconds)

* **Idle Sleep Mode (`--sleep-idle-seconds`, `-sis`):** Added a new CLI option for the `serve` command to automatically unload models and free up system memory after a specified duration of inactivity.
* **Thread-Safe Sleep Lifecycle:** Integrated an active background monitor loop (`idle_monitor_loop`) inside `RestHandler` using condition variables and mutexes.
* Automatically tracks active requests and hooks into API endpoints (`handle_chat`, `handle_generate`, etc.).
* Safely unloads LLM, ASR, and Embedding engines upon timeout.
* Transparently wakes up and reloads the required assets when a new request is received.