### PR TITLE
fix: read flm_version directly when checking compatibility (#545)

### DIFF
--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -48,9 +48,21 @@ bool ModelDownloader::is_model_downloaded(const std::string& model_tag, bool sub
 /// \return true if the model is compatible, false otherwise
 bool ModelDownloader::check_model_compatibility(const std::string& model_tag, bool sub_process_mode) {
     auto [new_model_tag, model_info] = supported_models.get_model_info(model_tag);
-    LM_Config config;
-    config.from_pretrained(this->supported_models.get_model_path(new_model_tag));
-    std::string flm_version = config.flm_version;
+    // A compatibility check only needs flm_version. Going through
+    // LM_Config::from_pretrained also runs the decoder-LM shape asserts
+    // (hidden_size > 0, intermediate_size > 0, ...), which abort on non-LM
+    // configs such as Whisper, whose HuggingFace config.json carries
+    // d_model rather than hidden_size. Read flm_version directly so the
+    // version check stays model-type agnostic and never trips those asserts.
+    // See https://github.com/FastFlowLM/FastFlowLM/issues/545
+    std::string model_path = this->supported_models.get_model_path(new_model_tag);
+    std::ifstream config_file(model_path + "/config.json");
+    if (!config_file.is_open()) {
+        std::cerr << "Failed to open file: " << model_path << std::endl;
+        exit(1);
+    }
+    nlohmann::json model_config = nlohmann::json::parse(config_file);
+    std::string flm_version = model_config.value("flm_version", "0.0.0");
     std::string flm_min_version = model_info["flm_min_version"];
     int l_l, m_l, r_l; //left, middle, right on local version
     int l_r, m_r, r_r; //left, middle, right on requried version


### PR DESCRIPTION
Fixes #545.

# Problem

After `flm pull whisper-v3:turbo`, both flm list and flm serve --asr 1 abort:
Assertion `this->hidden_size > 0` failed. (lm_config.hpp:121)

# Root cause

ModelDownloader::check_model_compatibility() reads each model's flm_version by constructing a base LM_Config and calling from_pretrained() — which
 runs the decoder-LM shape asserts (hidden_size > 0, …). A HuggingFace Whisper config.json carries d_model, not hidden_size, so hidden_size stays
0 and the assert fires. Whisper_Config exists and reads d_model, but from_pretrained is non-virtual and this scan path uses the base class for
every model regardless of model_type.

Why it doesn't reproduce on the default build: the linux-default preset is Release (-DNDEBUG), so assert() is a no-op and the path runs silently.
Builds with asserts live abort.

# Fix

A compatibility check only needs flm_version, so read it straight from config.json instead of constructing + validating a full LM config.

# Why this approach

- (this PR) read flm_version directly — model-type-agnostic (handles Whisper and any future non-LM config), minimal, and decouples a version check
 from LM-loadability validation.
- (alternative) route model_type == "whisper" to Whisper_Config here — uses the existing subclass but needs a model_type peek and only covers
Whisper.

A broader fix (make from_pretrained virtual + dispatch by model_type at all scan sites) is left out of scope. The Whisper loading path already
uses Whisper_Config and is untouched.

# Testing

Built with asserts live (no -DNDEBUG) against a pristine whisper-v3:turbo config: flm list completes (whisper-v3:turbo ✅) and `flm serve --asr 1` loads the model and starts the server. Both aborted before.
