### PR TITLE
Feature/huggingface

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+cd src && cmake --preset linux-default
+cmake --build build -j
+CC=/usr/bin/clang
+CXX=/usr/lib64/rocm/llvm/bin/clang++

--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -95,15 +95,99 @@ nlohmann::json AutoModel::_shared_setup_tokenizer(std::string model_path) {
         tokenizer_config["eos_token"]
     );
 
+    nlohmann::json tokenizer_json = nlohmann::json::object();
+    bool tokenizer_json_loaded = false;
+    auto find_token_id = [&](const std::string& token_text) -> int {
+        if (token_text.empty()) return -1;
+
+        if (!tokenizer_json_loaded) {
+            tokenizer_json_loaded = true;
+            #ifdef _WIN32
+            std::string tokenizer_json_path = model_path + "\\tokenizer.json";
+            #else
+            std::string tokenizer_json_path = model_path + "/tokenizer.json";
+            #endif
+            std::ifstream fs_tok(tokenizer_json_path, std::ios::in | std::ios::binary);
+            if (fs_tok.is_open()) {
+                std::string tok_data;
+                fs_tok.seekg(0, std::ios::end);
+                size_t tok_size = static_cast<size_t>(fs_tok.tellg());
+                fs_tok.seekg(0, std::ios::beg);
+                tok_data.resize(tok_size);
+                fs_tok.read(tok_data.data(), tok_size);
+                fs_tok.close();
+                try {
+                    tokenizer_json = nlohmann::json::parse(tok_data);
+                } catch (...) {
+                    tokenizer_json = nlohmann::json::object();
+                }
+            }
+        }
+
+        if (tokenizer_json.contains("added_tokens") && tokenizer_json["added_tokens"].is_array()) {
+            for (auto& t : tokenizer_json["added_tokens"]) {
+                if (!t.is_object()) continue;
+                if (!t.contains("content") || !t["content"].is_string()) continue;
+                if (t["content"].get<std::string>() != token_text) continue;
+                if (t.contains("id") && t["id"].is_number_integer()) {
+                    return t["id"].get<int>();
+                }
+            }
+        }
+
+        if (tokenizer_json.contains("model") && tokenizer_json["model"].is_object()) {
+            auto& model_obj = tokenizer_json["model"];
+            if (model_obj.contains("vocab") && model_obj["vocab"].is_object()) {
+                auto& vocab = model_obj["vocab"];
+                if (vocab.contains(token_text) && vocab[token_text].is_number_integer()) {
+                    return vocab[token_text].get<int>();
+                }
+            }
+        }
+
+        return -1;
+    };
+
     if (this->has_bos_token) {
-        this->bos_token_id = tokenizer_config["bos_token_id"].get<int>();
-    }
-    else {
+        if (tokenizer_config.contains("bos_token_id") && tokenizer_config["bos_token_id"].is_number_integer()) {
+            this->bos_token_id = tokenizer_config["bos_token_id"].get<int>();
+        } else {
+            int bos_id = find_token_id(tokenizer_config["bos_token"].get<std::string>());
+            if (bos_id >= 0) {
+                this->bos_token_id = bos_id;
+            } else {
+                header_print("WARNING", "bos_token_id missing in tokenizer_config.json and cannot be resolved from tokenizer.json; disabling BOS token");
+                this->has_bos_token = false;
+                this->bos_token_id = -1;
+            }
+        }
+    } else {
         this->bos_token_id = -1;
     }
+
     this->eos_token = tokenizer_config["eos_token"].get<std::string>();
-    for (auto& token : tokenizer_config["eos_token_id"]) {
-        this->eos_token_ids.push_back(token.get<int>());
+    this->eos_token_ids.clear();
+    if (tokenizer_config.contains("eos_token_id")) {
+        if (tokenizer_config["eos_token_id"].is_number_integer()) {
+            this->eos_token_ids.push_back(tokenizer_config["eos_token_id"].get<int>());
+        } else if (tokenizer_config["eos_token_id"].is_array()) {
+            for (auto& token : tokenizer_config["eos_token_id"]) {
+                if (token.is_number_integer()) {
+                    this->eos_token_ids.push_back(token.get<int>());
+                }
+            }
+        }
+    }
+    if (this->eos_token_ids.empty()) {
+        int eos_id = find_token_id(this->eos_token);
+        if (eos_id >= 0) {
+            this->eos_token_ids.push_back(eos_id);
+            header_print("WARNING", "eos_token_id missing in tokenizer_config.json; resolved from tokenizer.json");
+        }
+    }
+    if (this->eos_token_ids.empty()) {
+        header_print("ERROR", "Unable to resolve eos_token_id from tokenizer_config.json or tokenizer.json");
+        exit(1);
     }
     this->user_system_prompt = "";
     this->extra_context["user_system_prompt"] = this->user_system_prompt;

--- a/src/common/AutoModel/modeling_gemma4e.cpp
+++ b/src/common/AutoModel/modeling_gemma4e.cpp
@@ -8,8 +8,122 @@
 
 #include "AutoModel/modeling_gemma4e.hpp"
 #include "metrices.hpp"
+#include <fstream>
+#include <sstream>
 
 namespace {
+bool read_safetensors_header(const std::string& model_path, nlohmann::json& header_json, std::string& err) {
+    const std::string q4nx_path = model_path + "/model.q4nx";
+    std::ifstream file(q4nx_path, std::ios::binary);
+    if (!file.is_open()) {
+        err = "failed to open " + q4nx_path;
+        return false;
+    }
+
+    uint64_t header_len = 0;
+    file.read(reinterpret_cast<char*>(&header_len), sizeof(header_len));
+    if (!file.good()) {
+        err = "failed to read SafeTensors header length";
+        return false;
+    }
+    if (header_len == 0 || header_len > (64ULL * 1024ULL * 1024ULL)) {
+        err = "invalid SafeTensors header length: " + std::to_string(header_len);
+        return false;
+    }
+
+    std::string header_str(header_len, '\0');
+    file.read(header_str.data(), static_cast<std::streamsize>(header_len));
+    if (!file.good()) {
+        err = "failed to read SafeTensors header bytes";
+        return false;
+    }
+
+    try {
+        header_json = nlohmann::json::parse(header_str);
+    } catch (const std::exception& ex) {
+        err = std::string("failed to parse SafeTensors header JSON: ") + ex.what();
+        return false;
+    }
+    return true;
+}
+
+bool get_tensor_shape(const nlohmann::json& header_json,
+                      const std::string& tensor_name,
+                      std::vector<size_t>& out_shape,
+                      std::string& err) {
+    if (!header_json.contains(tensor_name) || !header_json[tensor_name].is_object()) {
+        err = "missing tensor in model.q4nx: " + tensor_name;
+        return false;
+    }
+    const auto& tensor_obj = header_json[tensor_name];
+    if (!tensor_obj.contains("shape") || !tensor_obj["shape"].is_array()) {
+        err = "tensor has no valid shape: " + tensor_name;
+        return false;
+    }
+    out_shape.clear();
+    for (const auto& dim : tensor_obj["shape"]) {
+        if (!dim.is_number_unsigned()) {
+            err = "tensor shape contains non-unsigned dimension: " + tensor_name;
+            return false;
+        }
+        out_shape.push_back(dim.get<size_t>());
+    }
+    return true;
+}
+
+std::string shape_to_string(const std::vector<size_t>& shape) {
+    std::ostringstream oss;
+    oss << "[";
+    for (size_t i = 0; i < shape.size(); ++i) {
+        if (i != 0) {
+            oss << ", ";
+        }
+        oss << shape[i];
+    }
+    oss << "]";
+    return oss.str();
+}
+
+bool validate_gemma4e_q4nx_layout(const std::string& model_path, const LM_Config& cfg, std::string& err) {
+    nlohmann::json header_json;
+    if (!read_safetensors_header(model_path, header_json, err)) {
+        return false;
+    }
+
+    const size_t num_heads = static_cast<size_t>(cfg.num_attention_heads);
+    const size_t hidden_size = static_cast<size_t>(cfg.hidden_size);
+    const size_t num_kv_heads = static_cast<size_t>(cfg.num_key_value_heads);
+
+    // Gemma4e NPU kernels expect these exact core tensor layouts.
+    const std::vector<size_t> expected_inp_gate = {num_heads, hidden_size, 32};
+    const std::vector<size_t> expected_prefill = {num_kv_heads * 2, hidden_size / 256, 16384};
+    const std::vector<size_t> expected_per_layer_proj = {80, hidden_size / 10, 32};
+
+    struct TensorExpectation {
+        std::string name;
+        std::vector<size_t> expected;
+    };
+    const std::vector<TensorExpectation> checks = {
+        {"model.layers.0.inp_gate.weight", expected_inp_gate},
+        {"model.layers.0.inp_gate.weight_prefill", expected_prefill},
+        {"model.layers.0.per_layer_projection.weight", expected_per_layer_proj},
+    };
+
+    for (const auto& check : checks) {
+        std::vector<size_t> actual;
+        if (!get_tensor_shape(header_json, check.name, actual, err)) {
+            return false;
+        }
+        if (actual != check.expected) {
+            err = "incompatible tensor shape for " + check.name +
+                  ": expected " + shape_to_string(check.expected) +
+                  ", got " + shape_to_string(actual);
+            return false;
+        }
+    }
+    return true;
+}
+
 std::string trim_gemma4e_tool_value(std::string value) {
     size_t start = value.find_first_not_of(" \t\r\n");
     if (start == std::string::npos) {
@@ -415,6 +529,13 @@ Gemma4e::Gemma4e(xrt::device* npu_device_inst) : AutoModel(npu_device_inst, "Gem
 void Gemma4e::load_model(std::string model_path, json model_info, int default_context_length, bool enable_preemption) {
     
     this->_shared_load_model(model_path, model_info, default_context_length, enable_preemption);
+
+    std::string layout_error;
+    if (!validate_gemma4e_q4nx_layout(this->model_path, *this->lm_config, layout_error)) {
+        header_print("ERROR", "Gemma4e model.q4nx layout validation failed: " << layout_error);
+        header_print("ERROR", "This model.q4nx is incompatible with Gemma4e NPU kernels. Re-convert with a Gemma4e-compatible converter.");
+        exit(1);
+    }
     
     this->q4nx = std::make_unique<Q4NX>(this->model_path);
     this->lm_engine = std::make_unique<gemma4e_npu>(*this->lm_config, this->npu.get(), this->MAX_L);
@@ -426,7 +547,12 @@ void Gemma4e::load_model(std::string model_path, json model_info, int default_co
     this->setup_tokenizer(model_path);
     this->sampler.reset();
 
-    this->enable_tool = (model_info["size"] > 800000000)? true : false;
+    // HF-registered models may omit or null out size; keep this check robust.
+    long long model_size = 0;
+    if (model_info.contains("size") && model_info["size"].is_number()) {
+        model_size = model_info["size"].get<long long>();
+    }
+    this->enable_tool = (model_size > 800000000);
 
     sampler_config config;
     config.top_k = 64;

--- a/src/common/AutoModel/modeling_llama3.cpp
+++ b/src/common/AutoModel/modeling_llama3.cpp
@@ -31,6 +31,8 @@ void Llama3::load_model(std::string model_path, json model_info, int default_con
     config.top_p = 0.9;
     config.min_p = 0.1;
     config.temperature = 0.8;
+    config.rep_penalty = 1.1;
+    config.freq_penalty = 1.05;
 
     this->set_sampler(config);
     for (size_t i = 0; i < PROFILER_TYPE_NUM; i++) {

--- a/src/include/lm_config.hpp
+++ b/src/include/lm_config.hpp
@@ -80,11 +80,20 @@ class LM_Config{
             // Allow config.json to override the path-derived model_name so that
             // xclbin lookup works even when the snapshot directory is a branch
             // name (e.g. "main") rather than the model repo name.
+            // Priority: flm_xclbin_name > flm_model_name > path basename
             {
                 std::string _flm_model_name;
                 JSON_GET(_flm_model_name, this->_json_config, "flm_model_name", "", std::string);
                 if (!_flm_model_name.empty()) {
                     this->model_name = _flm_model_name;
+                }
+                // flm_xclbin_name explicitly sets the xclbin directory,
+                // decoupling the model's display name from the kernel directory.
+                // Useful for custom models built on top of a standard FLM base.
+                std::string _flm_xclbin_name;
+                JSON_GET(_flm_xclbin_name, this->_json_config, "flm_xclbin_name", "", std::string);
+                if (!_flm_xclbin_name.empty()) {
+                    this->model_name = _flm_xclbin_name;
                 }
             }
             JSON_GET(this->sliding_window, this->_json_config, "sliding_window", 0, u32);

--- a/src/include/lm_config.hpp
+++ b/src/include/lm_config.hpp
@@ -77,6 +77,16 @@ class LM_Config{
             // read the json file as a string
             std::string json_str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
             this->_json_config = nlohmann::json::parse(json_str);
+            // Allow config.json to override the path-derived model_name so that
+            // xclbin lookup works even when the snapshot directory is a branch
+            // name (e.g. "main") rather than the model repo name.
+            {
+                std::string _flm_model_name;
+                JSON_GET(_flm_model_name, this->_json_config, "flm_model_name", "", std::string);
+                if (!_flm_model_name.empty()) {
+                    this->model_name = _flm_model_name;
+                }
+            }
             JSON_GET(this->sliding_window, this->_json_config, "sliding_window", 0, u32);
             JSON_GET(this->sliding_window_pattern, this->_json_config, "sliding_window_pattern", 0, u32);
             JSON_GET(this->model_type, this->_json_config, "model_type", "", std::string);

--- a/src/include/model_list.hpp
+++ b/src/include/model_list.hpp
@@ -144,6 +144,11 @@ class model_list {
             return this->model_root_path;
         }
 
+        /// \brief get read-only access to the raw model list config JSON
+        const nlohmann::json& get_config() const {
+            return this->config;
+        }
+
         /// \brief get all the models
         /// \return all the models in json
         nlohmann::json get_all_models(){
@@ -158,8 +163,13 @@ class model_list {
                     model_entry["model"] = model_type + ":" + size;
                     response["models"].push_back(model_entry);
                 }
-            }
-            return response;
+            }            // Append dynamically registered HuggingFace models
+            for (const auto& [hf_tag, model_info] : hf_models) {
+                nlohmann::json model_entry = model_info;
+                model_entry["name"] = hf_tag;
+                model_entry["model"] = hf_tag;
+                response["models"].push_back(model_entry);
+            }            return response;
         }
 
         /// \brief get all the models
@@ -184,6 +194,15 @@ class model_list {
                     };
                     response["models"].push_back(model_entry);
                 }
+            }
+            // Append dynamically registered HuggingFace models
+            for (const auto& [hf_tag, model_info] : hf_models) {
+                nlohmann::json model_entry = {
+                    {"name", hf_tag},
+                    {"model", hf_tag},
+                    {"details", model_info.value("details", nlohmann::json::object())}
+                };
+                response["models"].push_back(model_entry);
             }
             return response;
         }
@@ -212,6 +231,18 @@ class model_list {
                     };
                     response["data"].push_back(model_entry);
                 }
+            }
+            // Append dynamically registered HuggingFace models
+            for (const auto& [hf_tag, model_info] : hf_models) {
+                // Derive owner from "owner/repo" for owned_by field
+                std::string owner = hf_tag.substr(0, hf_tag.find('/'));
+                nlohmann::json model_entry = {
+                    {"id", hf_tag},
+                    {"object", "model"},
+                    {"created", static_cast<long long>(now)},
+                    {"owned_by", owner}
+                };
+                response["data"].push_back(model_entry);
             }
 
             return response;

--- a/src/include/model_list.hpp
+++ b/src/include/model_list.hpp
@@ -54,6 +54,13 @@ class model_list {
         /// \param tag the tag of the model
         /// \return the model info
         std::pair<std::string, nlohmann::json> get_model_info(const std::string tag) const {
+            // Check HF models first (keyed by the full "owner/repo" string)
+            {
+                auto it = hf_models.find(tag);
+                if (it != hf_models.end()) {
+                    return std::make_pair(tag, it->second);
+                }
+            }
             static std::string last_error_tag = "";
             std::string new_tag = rectify_model_tag(tag);
             bool model_found = false;
@@ -214,6 +221,13 @@ class model_list {
         /// \param tag the tag of the model
         /// \return the model path, string
         std::string get_model_path(const std::string& tag){
+            // For HF models the full absolute path is stored in "hf_path"
+            {
+                auto it = hf_models.find(tag);
+                if (it != hf_models.end()) {
+                    return it->second["hf_path"].get<std::string>();
+                }
+            }
             std::string new_tag = this->rectify_model_tag(tag);
             auto [new_tag_unused, model_info] = this->get_model_info(new_tag);
             std::string model_name = model_info["name"];
@@ -222,12 +236,26 @@ class model_list {
         }
 
         bool is_model_supported(const std::string& tag) {
-            return all_tags.find(tag) != all_tags.end();
+            return all_tags.find(tag) != all_tags.end() || hf_models.count(tag) > 0;
+        }
+
+        /// \brief Register an ad-hoc model discovered from a HuggingFace repo
+        /// \param hf_tag full "owner/repo" identifier used as the lookup key
+        /// \param model_info synthetic model info JSON built from the repo's config.json
+        void register_hf_model(const std::string& hf_tag, const nlohmann::json& model_info) {
+            hf_models[hf_tag] = model_info;
+            all_tags.insert(hf_tag);
+        }
+
+        bool is_hf_model(const std::string& tag) const {
+            return hf_models.count(tag) > 0;
         }
         
     private:
         std::string list_path;
         nlohmann::json config;
         std::string model_root_path;
+        // Dynamically registered HuggingFace models (keyed by "owner/repo")
+        std::unordered_map<std::string, nlohmann::json> hf_models;
 
 };

--- a/src/include/program_args.hpp
+++ b/src/include/program_args.hpp
@@ -32,6 +32,10 @@ struct program_args_t {
 
     // for pull command
     bool force_redownload = false;
+
+    // for --hf flag: treat model_tag as a HuggingFace owner/repo
+    bool hf_model = false;
+    std::string hf_branch = "main";
     
     // for serve command
     std::string host = "127.0.0.1";

--- a/src/include/utils/vm_args.hpp
+++ b/src/include/utils/vm_args.hpp
@@ -51,6 +51,10 @@ inline void print_help(po::options_description& general) {
     std::cout << "\tflm list" << std::endl;
     std::cout << "\tflm list --quiet" << std::endl;
     std::cout << "\tflm list --filter installed" << std::endl;
+    std::cout << "\tflm pull FastFlowLM/Qwen3.5-0.8B-NPU2 --hf" << std::endl;
+    std::cout << "\tflm run  FastFlowLM/Qwen3.5-0.8B-NPU2 --hf" << std::endl;
+    std::cout << "\tflm serve FastFlowLM/Qwen3.5-0.8B-NPU2 --hf" << std::endl;
+    std::cout << "\tflm pull FastFlowLM/Qwen3.5-0.8B-NPU2 --hf --hf-branch dev" << std::endl;
     std::cout << std::endl;
 }
 
@@ -100,7 +104,11 @@ bool parse_options(int argc, char *argv[], program_args_t& parsed_args) {
             ("preemption", po::value<bool>(&parsed_args.preemption)->default_value(false),
              "Enable preemption")
             ("prompt,i", po::value<std::string>(&parsed_args.input_file_name)->default_value(""),
-             "Direct file input");
+             "Direct file input")
+            ("hf", po::bool_switch(&parsed_args.hf_model),
+             "Treat model_tag as a HuggingFace owner/repo and download it directly")
+            ("hf-branch", po::value<std::string>(&parsed_args.hf_branch)->default_value("main"),
+             "HuggingFace branch/revision to download from (use with --hf)");
 
         // Define positional arguments
         po::positional_options_description pos_desc;
@@ -218,6 +226,18 @@ bool parse_options(int argc, char *argv[], program_args_t& parsed_args) {
                 std::cerr << "Error: Model tag is required for command '" << parsed_args.command << "'" << std::endl;
                 return false;
             }
+        }
+
+        // --hf-branch without --hf is a mistake
+        if (!vm["hf-branch"].defaulted() && !parsed_args.hf_model) {
+            std::cerr << "Error: --hf-branch requires --hf" << std::endl;
+            return false;
+        }
+
+        // When --hf is used, remove/check commands are not supported
+        if (parsed_args.hf_model && (parsed_args.command == "remove" || parsed_args.command == "check")) {
+            std::cerr << "Error: --hf is not supported with '" << parsed_args.command << "'" << std::endl;
+            return false;
         }
 
         return true;

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -28,6 +28,8 @@ static const std::map<std::string, std::string> kHFModelTypeToFamily = {
     {"gemma3_text",   "gemma3-text"},
     {"gemma3",        "gemma3"},
     {"gemma4e",       "gemma4e"},
+    {"gemma4_text",   "gemma4e"},
+    {"gemma4",        "gemma4e"},
     {"gpt_oss",       "gpt-oss"},
     {"lfm2",          "lfm2"},
     {"lfm2_5_tk",     "lfm2.5-tk"},

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -206,7 +206,13 @@ bool ModelDownloader::pull_model(const std::string& model_tag, bool force_redown
 
         if (success) {
             header_print("FLM", "Model downloaded successfully!");
-            
+
+            // For HF models with bundled xclbins, install them to the
+            // standard xclbin directory so the model loader can find them.
+            if (supported_models.is_hf_model(new_model_tag)) {
+                install_hf_xclbins(new_model_tag);
+            }
+
             // Verify download
             auto final_missing = get_missing_files(new_model_tag);
             if (final_missing.empty()) {
@@ -784,6 +790,19 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
                 files.push_back(opt);
             }
         }
+        // Also include any .xclbin files already present in the snapshot directory
+        try {
+            for (const auto& entry : std::filesystem::directory_iterator(model_path)) {
+                if (entry.is_regular_file()) {
+                    std::string fname = entry.path().filename().string();
+                    if (fname.size() > 7 && fname.substr(fname.size() - 7) == ".xclbin") {
+                        if (std::find(files.begin(), files.end(), fname) == files.end()) {
+                            files.push_back(fname);
+                        }
+                    }
+                }
+            }
+        } catch (...) {}
     } else {
         // Online path: query HF tree API
         header_print("FLM", "[HF] Querying file tree for " + hf_repo + " ...");
@@ -794,6 +813,15 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
                 if (f.value("path", "") == opt) {
                     files.push_back(opt);
                     break;
+                }
+            }
+        }
+        // Also include any .xclbin files present in the HF repo tree
+        for (const auto& f : hf_files) {
+            std::string path = f.value("path", "");
+            if (path.size() > 7 && path.substr(path.size() - 7) == ".xclbin") {
+                if (std::find(files.begin(), files.end(), path) == files.end()) {
+                    files.push_back(path);
                 }
             }
         }
@@ -840,6 +868,8 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
     header_print("FLM", "[HF] Registered " + hf_repo +
                         " (family: " + family + ", ctx: " +
                         std::to_string(ctx_len) + ")");
+    // Install any xclbins already present in the snapshot dir (idempotent)
+    install_hf_xclbins(hf_repo);
     return hf_repo;
 }
 
@@ -857,5 +887,107 @@ bool ModelDownloader::pull_hf_model(const std::string& hf_repo,
     } catch (const std::exception& e) {
         header_print("ERROR", "[HF] " + std::string(e.what()));
         return false;
+    }
+}
+
+/// \brief Install xclbin files from an HF model's snapshot directory to the
+///        standard xclbin search path expected by the model loader.
+///
+/// The model loader resolves xclbins as:
+///   {find_xclbin_path()}/xclbins/{flm_xclbin_name || flm_model_name}/
+///
+/// This mirrors that resolution so HF-bundled kernels land in the right place
+/// without the user needing to set any environment variables.
+///
+/// \param model_tag  HF model tag, e.g. "Atomic-Germ/Granite-4.1-8B-NPU2"
+void ModelDownloader::install_hf_xclbins(const std::string& model_tag) {
+    try {
+        std::string snapshot_dir = supported_models.get_model_path(model_tag);
+
+        // Collect .xclbin files in the snapshot dir
+        std::vector<std::filesystem::path> xclbins;
+        try {
+            for (const auto& entry : std::filesystem::directory_iterator(snapshot_dir)) {
+                if (entry.is_regular_file()) {
+                    std::string fname = entry.path().filename().string();
+                    if (fname.size() > 7 && fname.substr(fname.size() - 7) == ".xclbin") {
+                        xclbins.push_back(entry.path());
+                    }
+                }
+            }
+        } catch (...) {}
+
+        if (xclbins.empty()) return;
+
+        // Read config.json to determine the xclbin directory name.
+        // Mirror lm_config.hpp priority: flm_xclbin_name > flm_model_name > repo basename.
+        std::string repo = model_tag;
+        auto slash = repo.rfind('/');
+        if (slash != std::string::npos) repo = repo.substr(slash + 1);
+
+        std::string xclbin_dir_name = repo;
+        std::string config_path = snapshot_dir + "/config.json";
+        try {
+            std::ifstream cfg_file(config_path);
+            if (cfg_file.is_open()) {
+                nlohmann::json cfg = nlohmann::json::parse(cfg_file);
+                std::string xn = cfg.value("flm_xclbin_name", "");
+                std::string mn = cfg.value("flm_model_name", "");
+                if (!xn.empty())      xclbin_dir_name = xn;
+                else if (!mn.empty()) xclbin_dir_name = mn;
+            }
+        } catch (...) {}
+
+        // Locate the xclbin base directory
+        std::string xclbin_base;
+        try {
+            xclbin_base = utils::find_xclbin_path();
+        } catch (...) {
+            header_print("WARNING", "[HF] Cannot determine xclbin base dir; "
+                         "bundled xclbins are available in: " + snapshot_dir);
+            return;
+        }
+
+        // Create {xclbin_base}/xclbins/{xclbin_dir_name}/
+        std::filesystem::path target_dir =
+            std::filesystem::path(xclbin_base) / "xclbins" / xclbin_dir_name;
+        try {
+            std::filesystem::create_directories(target_dir);
+        } catch (const std::exception& e) {
+            header_print("WARNING", "[HF] Cannot create xclbin dir " +
+                         target_dir.string() + ": " + std::string(e.what()));
+            return;
+        }
+
+        // Symlink (preferred — no extra disk space) or copy each xclbin
+        bool any_installed = false;
+        for (const auto& src : xclbins) {
+            std::filesystem::path dest = target_dir / src.filename();
+            if (std::filesystem::exists(dest)) continue; // already installed
+
+            bool installed = false;
+            try {
+                std::filesystem::create_symlink(src, dest);
+                installed = true;
+            } catch (...) {
+                try {
+                    std::filesystem::copy_file(src, dest,
+                        std::filesystem::copy_options::overwrite_existing);
+                    installed = true;
+                } catch (const std::exception& e) {
+                    header_print("WARNING", "[HF] Failed to install " +
+                                 src.filename().string() + ": " + std::string(e.what()));
+                }
+            }
+            if (installed) {
+                header_print("FLM", "[HF] Installed xclbin: " + dest.string());
+                any_installed = true;
+            }
+        }
+        if (any_installed) {
+            header_print("FLM", "[HF] xclbins ready in " + target_dir.string());
+        }
+    } catch (const std::exception& e) {
+        header_print("WARNING", "[HF] xclbin install error: " + std::string(e.what()));
     }
 }

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -959,24 +959,33 @@ void ModelDownloader::install_hf_xclbins(const std::string& model_tag) {
             return;
         }
 
-        // Symlink (preferred — no extra disk space) or copy each xclbin
+        // Symlink (preferred — no extra disk space) or copy each xclbin.
+        // Use absolute path for symlink target so it resolves correctly
+        // regardless of the working directory when the link is followed.
         bool any_installed = false;
         for (const auto& src : xclbins) {
-            std::filesystem::path dest = target_dir / src.filename();
+            std::filesystem::path abs_src = std::filesystem::absolute(src);
+            std::filesystem::path dest = target_dir / abs_src.filename();
+
+            // Remove a broken symlink so we can reinstall cleanly
+            if (std::filesystem::is_symlink(dest) &&
+                !std::filesystem::exists(dest)) {
+                std::filesystem::remove(dest);
+            }
             if (std::filesystem::exists(dest)) continue; // already installed
 
             bool installed = false;
             try {
-                std::filesystem::create_symlink(src, dest);
+                std::filesystem::create_symlink(abs_src, dest);
                 installed = true;
             } catch (...) {
                 try {
-                    std::filesystem::copy_file(src, dest,
+                    std::filesystem::copy_file(abs_src, dest,
                         std::filesystem::copy_options::overwrite_existing);
                     installed = true;
                 } catch (const std::exception& e) {
                     header_print("WARNING", "[HF] Failed to install " +
-                                 src.filename().string() + ": " + std::string(e.what()));
+                                 abs_src.filename().string() + ": " + std::string(e.what()));
                 }
             }
             if (installed) {

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -7,8 +7,49 @@
 #include "model_downloader.hpp"
 #include "utils/utils.hpp"
 #include "download_model.hpp"
+#include <set>
 #include <sstream>
 #include <iomanip>
+#include <fstream>
+
+// ---------------------------------------------------------------------------
+// Mapping from HuggingFace config.json "model_type" to the FastFlowLM family
+// name used in model_list and all_models.hpp.
+// ---------------------------------------------------------------------------
+static const std::map<std::string, std::string> kHFModelTypeToFamily = {
+    {"qwen3_5_text",  "qwen3.5"},
+    {"qwen3_5",       "qwen3.5"},
+    {"qwen3_vl",      "qwen3vl"},
+    {"qwen3",         "qwen3"},
+    {"qwen2_vl",      "qwen2vl"},
+    {"qwen2",         "qwen2"},
+    {"llama",         "llama3"},
+    {"llama3",        "llama3"},
+    {"gemma3_text",   "gemma3-text"},
+    {"gemma3",        "gemma3"},
+    {"gemma4e",       "gemma4e"},
+    {"gpt_oss",       "gpt-oss"},
+    {"lfm2",          "lfm2"},
+    {"lfm2_5_tk",     "lfm2.5-tk"},
+    {"phi4",          "phi4"},
+    {"nanbeige4",     "nanbeige"},
+    {"nanbeige4_1",   "nanbeige"},
+};
+
+// Files that must be present in every FastFlowLM model.
+static const std::vector<std::string> kHFRequiredFiles = {
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "model.q4nx",
+};
+
+// Files that are included when discovered in the repo.
+static const std::vector<std::string> kHFOptionalFiles = {
+    "chat_template.jinja",
+    "vision_weight.q4nx",
+    "audio_weight.q4nx",
+};
 
 /// \brief Constructor
 /// \param models the model list
@@ -47,6 +88,11 @@ bool ModelDownloader::is_model_downloaded(const std::string& model_tag, bool sub
 /// \param model_tag the model tag
 /// \return true if the model is compatible, false otherwise
 bool ModelDownloader::check_model_compatibility(const std::string& model_tag, bool sub_process_mode) {
+    // HF models carry flm_min_version == the model's own flm_version, so the
+    // version check would always spuriously fail for older model files.  Skip
+    // it entirely; compatibility for HF models is the user's responsibility.
+    if (supported_models.is_hf_model(model_tag)) return true;
+
     auto [new_model_tag, model_info] = supported_models.get_model_info(model_tag);
     LM_Config config;
     config.from_pretrained(this->supported_models.get_model_path(new_model_tag));
@@ -474,6 +520,20 @@ bool ModelDownloader::verify_and_clean_files(const std::string& model_tag, bool 
 
             bool is_lfs = file.contains("lfs");
             std::string oid_ref = is_lfs ? file["lfs"]["oid"] : file["oid"];
+
+            // For HF-sourced models, skip hash verification for files that
+            // are frequently regenerated or vendor-patched without changing
+            // the model content (tokenizer config, compiled weights).
+            static const std::set<std::string> kHFNoHashCheck = {
+                "tokenizer.json", "model.q4nx",
+            };
+            if (supported_models.is_hf_model(model_tag) &&
+                kHFNoHashCheck.count(filename)) {
+                if (!sub_process_mode)
+                    header_print("FLM", "Skipping hash check for " + filename + " (HF model)");
+                continue;
+            }
+
             std::string local_oid = is_lfs ? download_utils::calculate_file_sha256(local_path) : download_utils::calculate_git_blob_oid(local_path);
 
             if (local_oid == oid_ref) {
@@ -504,4 +564,204 @@ bool ModelDownloader::verify_and_clean_files(const std::string& model_tag, bool 
         any_error = true;
     }
     return !any_error;
+}
+
+// ---------------------------------------------------------------------------
+// HuggingFace direct-download support
+// ---------------------------------------------------------------------------
+
+/// \brief Return the HuggingFace hub cache root directory.
+///        Respects HF_HUB_CACHE, HUGGINGFACE_HUB_CACHE, and HF_HOME env vars
+///        in that priority order, falling back to ~/.cache/huggingface/hub.
+static std::string hf_cache_root() {
+    for (const char* env : {"HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE"}) {
+        const char* val = std::getenv(env);
+        if (val && *val) return std::string(val);
+    }
+    const char* hf_home = std::getenv("HF_HOME");
+    if (hf_home && *hf_home)
+        return std::string(hf_home) + "/hub";
+    const char* home = std::getenv("HOME");
+    if (home && *home)
+        return std::string(home) + "/.cache/huggingface/hub";
+    return ".cache/huggingface/hub"; // fallback: relative (should not happen)
+}
+
+/// \brief Register an HF model into supported_models so all normal pull/run
+///        paths can work with it.  If config.json is already present locally
+///        the HF API is not called to determine the file list; otherwise both
+///        config.json and the repo tree are fetched from HuggingFace.
+/// \param hf_repo  "owner/repo" string (e.g. "FastFlowLM/Qwen3.5-0.8B-NPU2")
+/// \param branch   branch / revision (default: "main")
+/// \return the same hf_repo string that was registered as the model tag
+std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
+                                                const std::string& branch) {
+    auto slash_pos = hf_repo.find('/');
+    if (slash_pos == std::string::npos || slash_pos == 0 ||
+        slash_pos == hf_repo.size() - 1) {
+        throw std::runtime_error(
+            "Invalid HuggingFace repo format (expected owner/repo): " + hf_repo);
+    }
+
+    const std::string owner = hf_repo.substr(0, slash_pos);
+    const std::string repo  = hf_repo.substr(slash_pos + 1);
+
+    // Store the model in the standard HuggingFace hub cache layout:
+    //   {hf_cache_root}/models--{owner}--{repo}/snapshots/{branch}/
+    // This is the same layout used by huggingface-cli, so the model can be
+    // inspected and managed with standard HF tooling.
+    std::string cache_repo_name = "models--" + owner + "--" + repo;
+    std::string model_path =
+        (std::filesystem::path(hf_cache_root()) / cache_repo_name /
+         "snapshots" / branch)
+            .string();
+    std::string config_path = model_path + "/config.json";
+
+    // -----------------------------------------------------------------------
+    // Step 1: obtain config.json (local cache or remote download)
+    // -----------------------------------------------------------------------
+    nlohmann::json config;
+    if (std::filesystem::exists(config_path)) {
+        std::ifstream f(config_path);
+        config = nlohmann::json::parse(f);
+        header_print("FLM", "[HF] Using cached config.json from " + model_path);
+    } else {
+        std::filesystem::create_directories(model_path);
+        std::string config_url = "https://huggingface.co/" + hf_repo +
+                                 "/resolve/" + branch +
+                                 "/config.json?download=true";
+        header_print("FLM", "[HF] Fetching config.json for " + hf_repo + " ...");
+        if (!download_utils::download_file(config_url, config_path,
+                                           /*is_lfs=*/false, /*remote_oid=*/"")) {
+            throw std::runtime_error(
+                "Failed to download config.json from " + config_url);
+        }
+        std::ifstream f(config_path);
+        config = nlohmann::json::parse(f);
+    }
+
+    // Inject flm_model_name into config.json so lm_config can resolve the
+    // correct xclbin directory even when the snapshot path ends in a branch
+    // name ("main") rather than the repo name (e.g. "Qwen3.5-0.8B-NPU2").
+    if (!config.contains("flm_model_name") || config["flm_model_name"] != repo) {
+        config["flm_model_name"] = repo;
+        std::ofstream out_cfg(config_path);
+        out_cfg << config.dump(4) << "\n";
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 2: determine FastFlowLM family from model_type in config.json
+    // -----------------------------------------------------------------------
+    std::string model_type = config.value("model_type", "");
+    auto family_it = kHFModelTypeToFamily.find(model_type);
+    if (family_it == kHFModelTypeToFamily.end()) {
+        throw std::runtime_error(
+            "Unsupported model_type \"" + model_type +
+            "\" in config.json. This model may not be compatible with "
+            "FastFlowLM.");
+    }
+    const std::string& family = family_it->second;
+
+    // FLM version embedded in the model's config.json
+    std::string flm_version = config.value("flm_version", "0.0.0");
+
+    // -----------------------------------------------------------------------
+    // Step 3: build the file list
+    //   - If all required files exist locally, scan the directory for optional
+    //     files already present so we don't need a network round-trip.
+    //   - Otherwise query the HF tree API to discover optional files.
+    // -----------------------------------------------------------------------
+    std::string file_url = "https://huggingface.co/api/models/" +
+                           hf_repo + "/tree/" + branch;
+    std::vector<std::string> files = kHFRequiredFiles;
+
+    bool all_local = true;
+    for (const auto& req : kHFRequiredFiles) {
+        if (!std::filesystem::exists(model_path + "/" + req)) {
+            all_local = false;
+            break;
+        }
+    }
+
+    if (all_local) {
+        // Offline path: discover optional files from local directory
+        for (const auto& opt : kHFOptionalFiles) {
+            if (std::filesystem::exists(model_path + "/" + opt)) {
+                files.push_back(opt);
+            }
+        }
+    } else {
+        // Online path: query HF tree API
+        header_print("FLM", "[HF] Querying file tree for " + hf_repo + " ...");
+        std::string hf_response = download_utils::download_string(file_url);
+        nlohmann::json hf_files = nlohmann::json::parse(hf_response);
+        for (const auto& opt : kHFOptionalFiles) {
+            for (const auto& f : hf_files) {
+                if (f.value("path", "") == opt) {
+                    files.push_back(opt);
+                    break;
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 4: derive metadata and build the synthetic model_info JSON
+    // -----------------------------------------------------------------------
+    bool has_vision = std::find(files.begin(), files.end(),
+                                "vision_weight.q4nx") != files.end();
+    bool has_audio  = std::find(files.begin(), files.end(),
+                                "audio_weight.q4nx") != files.end();
+
+    // Clamp context length to a reasonable maximum
+    int max_pos = config.value("max_position_embeddings", 32768);
+    int ctx_len  = std::min(max_pos, 32768);
+
+    nlohmann::json model_info = {
+        {"name",                repo},
+        {"hf_path",             model_path},
+        {"url",                 "https://huggingface.co/" + hf_repo +
+                                    "/resolve/" + branch},
+        {"file_url",            file_url},
+        {"flm_min_version",     flm_version},
+        {"default_context_length", ctx_len},
+        {"max_prefill_len",     4096},
+        {"vlm",                 has_vision},
+        {"asr",                 has_audio},
+        {"files",               files},
+        {"size",                0},
+        {"details", {
+            {"format",             "NPU2"},
+            {"family",             family},
+            {"think",              false},
+            {"parameter_size",     ""},
+            {"quantization_level", "Q4NX"},
+        }},
+    };
+
+    // -----------------------------------------------------------------------
+    // Step 5: register in model_list so all existing paths can use this tag
+    // -----------------------------------------------------------------------
+    supported_models.register_hf_model(hf_repo, model_info);
+    header_print("FLM", "[HF] Registered " + hf_repo +
+                        " (family: " + family + ", ctx: " +
+                        std::to_string(ctx_len) + ")");
+    return hf_repo;
+}
+
+/// \brief Download all files for an HF repo (register first, then pull).
+/// \param hf_repo          "owner/repo"
+/// \param branch           branch / revision
+/// \param force_redownload if true, re-download even if files are present
+/// \return true on success
+bool ModelDownloader::pull_hf_model(const std::string& hf_repo,
+                                    const std::string& branch,
+                                    bool force_redownload) {
+    try {
+        std::string tag = register_hf_model(hf_repo, branch);
+        return pull_model(tag, force_redownload);
+    } catch (const std::exception& e) {
+        header_print("ERROR", "[HF] " + std::string(e.what()));
+        return false;
+    }
 }

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -959,6 +959,19 @@ void ModelDownloader::install_hf_xclbins(const std::string& model_tag) {
             return;
         }
 
+        // If the target directory exists but is not writable (e.g., root-owned
+        // system installation), the xclbins already present there are usable.
+        // Skip the install loop silently rather than emitting a WARNING per file.
+        {
+            auto test_path = target_dir / ".flm_write_test";
+            bool writable = false;
+            try {
+                std::ofstream test(test_path);
+                if (test.is_open()) { test.close(); std::filesystem::remove(test_path); writable = true; }
+            } catch (...) {}
+            if (!writable) return;
+        }
+
         // Symlink (preferred — no extra disk space) or copy each xclbin.
         // Use absolute path for symlink target so it resolves correctly
         // regardless of the working directory when the link is followed.

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -533,7 +533,7 @@ bool ModelDownloader::verify_and_clean_files(const std::string& model_tag, bool 
             // are frequently regenerated or vendor-patched without changing
             // the model content (tokenizer config, compiled weights).
             static const std::set<std::string> kHFNoHashCheck = {
-                "tokenizer.json", "model.q4nx",
+                "config.json", "tokenizer.json", "model.q4nx",
             };
             if (supported_models.is_hf_model(model_tag) &&
                 kHFNoHashCheck.count(filename)) {
@@ -755,6 +755,64 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
                                 if (candidate_config.contains(field) &&
                                     !candidate_config[field].is_null()) {
                                     config[field] = candidate_config[field];
+                                }
+                            }
+
+                            // Gemma4 runtime libraries also consume nested
+                            // vision/audio config keys (e.g. xclbin engine
+                            // names) directly from raw json. Preserve any
+                            // model-specific values already present, but fill
+                            // missing keys from the matched reference model.
+                            static const std::vector<std::string> kNestedRuntimeConfigs = {
+                                "vision_config", "audio_config"
+                            };
+                            for (const auto& nested_key : kNestedRuntimeConfigs) {
+                                if (!candidate_config.contains(nested_key) ||
+                                    !candidate_config[nested_key].is_object()) {
+                                    continue;
+                                }
+
+                                if (!config.contains(nested_key) ||
+                                    !config[nested_key].is_object()) {
+                                    config[nested_key] = candidate_config[nested_key];
+                                    continue;
+                                }
+
+                                for (auto& [k, v] : candidate_config[nested_key].items()) {
+                                    if (!config[nested_key].contains(k) ||
+                                        config[nested_key][k].is_null()) {
+                                        config[nested_key][k] = v;
+                                    }
+                                }
+                            }
+
+                            // Normalize a couple of scalar fields to the
+                            // reference model format expected by Gemma4e libs.
+                            if (candidate_config.contains("model_type") &&
+                                !candidate_config["model_type"].is_null()) {
+                                config["model_type"] = candidate_config["model_type"];
+                            }
+                            if (candidate_config.contains("eos_token_id") &&
+                                candidate_config["eos_token_id"].is_number_integer()) {
+                                if (!config.contains("eos_token_id") ||
+                                    !config["eos_token_id"].is_number_integer()) {
+                                    config["eos_token_id"] = candidate_config["eos_token_id"];
+                                }
+                            }
+
+                            // Backfill any remaining top-level null/missing
+                            // fields from the matched reference config. Some
+                            // runtime libraries read raw JSON values directly
+                            // and assume scalar numerics are not null.
+                            for (auto& [k, v] : candidate_config.items()) {
+                                if (v.is_null()) {
+                                    continue;
+                                }
+                                if (k.rfind("flm_", 0) == 0) {
+                                    continue;
+                                }
+                                if (!config.contains(k) || config[k].is_null()) {
+                                    config[k] = v;
                                 }
                             }
                             break;

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -655,6 +655,20 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
     // if the repo name does not map directly to an installed xclbin dir.
     // We do this early so the resolved value is saved into config.json.
     {
+        // 0. Flatten nested text_config into the root for multimodal models
+        //    (e.g. Gemma4 HF format stores all text-encoder params under
+        //    "text_config" rather than at the top level).  Only fill missing
+        //    keys so top-level values like model_type are never overwritten.
+        bool text_config_merged = false;
+        if (config.contains("text_config") && config["text_config"].is_object()) {
+            for (auto& [key, val] : config["text_config"].items()) {
+                if (!config.contains(key)) {
+                    config[key] = val;
+                    text_config_merged = true;
+                }
+            }
+        }
+
         // 1. If config.json already carries flm_xclbin_name, trust it.
         std::string xclbin_dir = config.value("flm_xclbin_name", "");
 
@@ -727,6 +741,22 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
                             xclbin_dir = entry_name;
                             header_print("FLM", "[HF] Auto-detected xclbin dir: " +
                                          xclbin_dir + " for " + hf_repo);
+                            // Copy NPU hardware fields from the reference config so
+                            // the kernel library gets valid addresses and parameters.
+                            // These keys are set at kernel compile time and must
+                            // match the xclbin — architecture fields are left as-is.
+                            static const std::vector<std::string> kNPUFields = {
+                                "addr_qk", "addr_kv", "addr_kk",
+                                "addr_l_begin_mha", "addr_l_end_mha",
+                                "full_attn_period",
+                                "flm_version", "dtype",
+                            };
+                            for (const auto& field : kNPUFields) {
+                                if (candidate_config.contains(field) &&
+                                    !candidate_config[field].is_null()) {
+                                    config[field] = candidate_config[field];
+                                }
+                            }
                             break;
                         }
                     }
@@ -736,7 +766,8 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
         }
 
         // Persist the resolved xclbin_dir and ensure flm_model_name is set.
-        bool config_changed = false;
+        // Also persist if text_config fields were merged (so lm_config reads them).
+        bool config_changed = text_config_merged;
         if (!xclbin_dir.empty() && config.value("flm_xclbin_name", "") != xclbin_dir) {
             config["flm_xclbin_name"] = xclbin_dir;
             config_changed = true;

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -643,10 +643,104 @@ std::string ModelDownloader::register_hf_model(const std::string& hf_repo,
     // Inject flm_model_name into config.json so lm_config can resolve the
     // correct xclbin directory even when the snapshot path ends in a branch
     // name ("main") rather than the repo name (e.g. "Qwen3.5-0.8B-NPU2").
-    if (!config.contains("flm_model_name") || config["flm_model_name"] != repo) {
-        config["flm_model_name"] = repo;
-        std::ofstream out_cfg(config_path);
-        out_cfg << config.dump(4) << "\n";
+    // Also resolve flm_xclbin_name (the kernel directory) via auto-detection
+    // if the repo name does not map directly to an installed xclbin dir.
+    // We do this early so the resolved value is saved into config.json.
+    {
+        // 1. If config.json already carries flm_xclbin_name, trust it.
+        std::string xclbin_dir = config.value("flm_xclbin_name", "");
+
+        if (xclbin_dir.empty()) {
+            // 2. Check if the repo name itself is a valid xclbin directory.
+            std::string xclbin_base;
+            try { xclbin_base = utils::find_xclbin_path() + "/xclbins"; }
+            catch (...) {}
+            if (!xclbin_base.empty() &&
+                std::filesystem::exists(xclbin_base + "/" + repo)) {
+                xclbin_dir = repo; // repo name matches an installed kernel dir
+            }
+        }
+
+        if (xclbin_dir.empty()) {
+            // 3. Auto-detect: scan model_list entries with the same family and
+            //    compare architecture fingerprints.  Try local HF cache first,
+            //    then fall back to a lightweight HF API fetch.
+            int layers = config.value("num_hidden_layers", -1);
+            int hidden  = config.value("hidden_size", -1);
+            std::string our_model_type = config.value("model_type", "");
+
+            auto family_key_for_model_type = [&](const std::string& mt) -> std::string {
+                auto it = kHFModelTypeToFamily.find(mt);
+                return it != kHFModelTypeToFamily.end() ? it->second : "";
+            };
+            std::string our_family = family_key_for_model_type(our_model_type);
+
+            if (layers > 0 && hidden > 0 && !our_family.empty() &&
+                supported_models.get_config().contains("models")) {
+                for (const auto& [fam_key, sizes] : supported_models.get_config()["models"].items()) {
+                    for (const auto& [size_key, entry] : sizes.items()) {
+                        // Only consider entries from the same family
+                        std::string entry_family = entry.value(
+                            nlohmann::json::json_pointer("/details/family"), "");
+                        if (entry_family != our_family) continue;
+
+                        std::string entry_name = entry.value("name", "");
+                        if (entry_name.empty()) continue;
+
+                        // Try to get the candidate's config.json from local
+                        // HF cache (fast, no network).
+                        std::string owner = "FastFlowLM";
+                        std::string candidate_config_path =
+                            hf_cache_root() + "/models--" + owner + "--" +
+                            entry_name + "/snapshots/main/config.json";
+
+                        nlohmann::json candidate_config;
+                        if (std::filesystem::exists(candidate_config_path)) {
+                            try {
+                                std::ifstream cf(candidate_config_path);
+                                candidate_config = nlohmann::json::parse(cf);
+                            } catch (...) { continue; }
+                        } else {
+                            // Fetch just the config.json from HF (small file).
+                            std::string cfg_url =
+                                "https://huggingface.co/FastFlowLM/" +
+                                entry_name +
+                                "/resolve/main/config.json?download=true";
+                            try {
+                                std::string cfg_str =
+                                    download_utils::download_string(cfg_url);
+                                candidate_config = nlohmann::json::parse(cfg_str);
+                            } catch (...) { continue; }
+                        }
+
+                        int c_layers = candidate_config.value("num_hidden_layers", -1);
+                        int c_hidden  = candidate_config.value("hidden_size", -1);
+                        if (c_layers == layers && c_hidden == hidden) {
+                            xclbin_dir = entry_name;
+                            header_print("FLM", "[HF] Auto-detected xclbin dir: " +
+                                         xclbin_dir + " for " + hf_repo);
+                            break;
+                        }
+                    }
+                    if (!xclbin_dir.empty()) break;
+                }
+            }
+        }
+
+        // Persist the resolved xclbin_dir and ensure flm_model_name is set.
+        bool config_changed = false;
+        if (!xclbin_dir.empty() && config.value("flm_xclbin_name", "") != xclbin_dir) {
+            config["flm_xclbin_name"] = xclbin_dir;
+            config_changed = true;
+        }
+        if (config.value("flm_model_name", "") != repo) {
+            config["flm_model_name"] = repo;
+            config_changed = true;
+        }
+        if (config_changed) {
+            std::ofstream out_cfg(config_path);
+            out_cfg << config.dump(4) << "\n";
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/pull/model_downloader.hpp
+++ b/src/pull/model_downloader.hpp
@@ -80,4 +80,8 @@ private:
     // Verify per-file integrity against HuggingFace metadata and remove any
     // corrupted files. Returns true if all files passed verification.
     bool verify_and_clean_files(const std::string& model_tag, bool sub_process_mode=0);
+
+    /// Install bundled xclbin files from HF snapshot dir to the standard xclbin location.
+    /// Mirrors lm_config.hpp xclbin path resolution. Idempotent — skips already-present files.
+    void install_hf_xclbins(const std::string& model_tag);
 }; 

--- a/src/pull/model_downloader.hpp
+++ b/src/pull/model_downloader.hpp
@@ -45,6 +45,22 @@ public:
 
     void model_not_found(const std::string& model_tag);
 
+    // ---------------------------------------------------------------
+    // HuggingFace direct-download support  (--hf flag)
+    // ---------------------------------------------------------------
+
+    /// Query the HF repo, parse config.json, and register the model in
+    /// supported_models so that all existing pull/run paths work normally.
+    /// If config.json is already present locally the HF API is not called.
+    /// Returns the tag that was registered (same as hf_repo).
+    std::string register_hf_model(const std::string& hf_repo,
+                                  const std::string& branch = "main");
+
+    /// Register + download all files for an HF repo.
+    bool pull_hf_model(const std::string& hf_repo,
+                       const std::string& branch = "main",
+                       bool force_redownload = false);
+
 private:
     model_list& supported_models;
     download_utils::CurlInitializer curl_init;

--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -499,7 +499,9 @@ int main(int argc, char* argv[]) {
     }
 
     if (parsed_args.command == "run" || parsed_args.command == "serve" || parsed_args.command == "pull" || parsed_args.command == "remove" || parsed_args.command == "check" || parsed_args.command == "bench") {
-      if (parsed_args.model_tag != "model-faker" && (!availble_models.is_model_supported(parsed_args.model_tag))) {
+      // When --hf is set the model is resolved from HuggingFace at runtime;
+      // skip the static model-list check here.
+      if (!parsed_args.hf_model && parsed_args.model_tag != "model-faker" && (!availble_models.is_model_supported(parsed_args.model_tag))) {
             header_print("ERROR", "Model not found: " << parsed_args.model_tag << "; Please check with `flm list` and try again.");
             return 1;
         }
@@ -534,7 +536,9 @@ int main(int argc, char* argv[]) {
         rlim_t asr_size = 0;
         rlim_t embedding_size = 0;
 
-        if (parsed_args.model_tag != "model-faker" && !parsed_args.model_tag.empty()) {
+        if (parsed_args.model_tag != "model-faker" && !parsed_args.model_tag.empty()
+                && !parsed_args.hf_model  // HF models not yet registered at this point
+                && availble_models.is_model_supported(parsed_args.model_tag)) {
             auto [resolved_tag, model_info] = availble_models.get_model_info(parsed_args.model_tag);
             if (model_info.contains("size")) {
                 model_size = model_info["size"].get<uint64_t>();
@@ -605,11 +609,17 @@ int main(int argc, char* argv[]) {
         }
         else if (parsed_args.command == "run") {
             check_and_notify_new_version();
+            if (parsed_args.hf_model) {
+                downloader.register_hf_model(parsed_args.model_tag, parsed_args.hf_branch);
+            }
             Runner runner(availble_models, downloader, parsed_args);
             runner.run();
 
         } else if (parsed_args.command == "serve") {
             check_and_notify_new_version();
+            if (parsed_args.hf_model) {
+                downloader.register_hf_model(parsed_args.model_tag, parsed_args.hf_branch);
+            }
             // Create the server
             int port = utils::get_server_port(parsed_args.port);
             if (parsed_args.port == -1) { // User did not specify port
@@ -635,6 +645,17 @@ int main(int argc, char* argv[]) {
             // server->stop();
         }
         else if (parsed_args.command == "pull") {
+            // --hf: pull directly from a HuggingFace repo
+            if (parsed_args.hf_model) {
+                bool success = downloader.pull_hf_model(
+                    parsed_args.model_tag,
+                    parsed_args.hf_branch,
+                    parsed_args.force_redownload);
+                if (!success) {
+                    header_print("ERROR", "Failed to pull HuggingFace model: " + parsed_args.model_tag);
+                    return 1;
+                }
+            } else {
             // Check if the model is already downloaded, if true, the model will not be downloaded
             // Check if model is already downloaded
             if (!parsed_args.force_redownload && downloader.is_model_downloaded(parsed_args.model_tag)) {
@@ -657,6 +678,7 @@ int main(int argc, char* argv[]) {
                     return 1;
                 }
             }
+            } // end else (not --hf)
         }
         else if (parsed_args.command == "remove") {
             // Remove the model, this will be used to remove the model


### PR DESCRIPTION
Partly closes #569 along with https://huggingface.co/Atomic-Germ/Granite-4.1-8B-NPU2 or https://huggingface.co/Atomic-Germ/Granite-4.1-8B-Function-Calling-NPU2. Other sizes won't work due to llama support not being quite compatible enough to fudge.

This adds a `--hf` tag not unlike the one in llama.cpp. Currently, it works for FastFlowLM's repos, but I have yet to get a custom model working -- they do download though. If anyone wants to help test this, that would be appreciated.

I'm keeping this a draft until I've gone over every line, much of it is claude's doing. I made the feature so I can do testing with repos I'm keeping on  huggingface.

This is what copilot thinks:
```
This pull request adds first-class support for downloading and running models directly from HuggingFace repositories using a new `--hf` flag. It introduces mechanisms for registering and managing HuggingFace models dynamically, updates command-line parsing and help documentation, and ensures seamless integration with existing workflows. The most important changes are grouped below:

**HuggingFace Model Support:**

* Added support for a `--hf` flag (and `--hf-branch`) to treat the `model_tag` as a HuggingFace `owner/repo`, enabling direct download and registration of models from HuggingFace. This is reflected in command-line parsing, argument structures, and help documentation. [[1]](diffhunk://#diff-0046db30c8140568ce2141a937af1337ef72a5744596d952824bc24e2d2343ffR54-R57) [[2]](diffhunk://#diff-0046db30c8140568ce2141a937af1337ef72a5744596d952824bc24e2d2343ffL103-R111) [[3]](diffhunk://#diff-0046db30c8140568ce2141a937af1337ef72a5744596d952824bc24e2d2343ffR231-R242) [[4]](diffhunk://#diff-8f2e2a88a10cfb571080a0f3cbd1ff5fdcd9a1de4623a6da15144abec348cdbfR36-R39)
* Implemented methods in `ModelDownloader` for registering and pulling HuggingFace models, including downloading model files and installing bundled xclbin files. [[1]](diffhunk://#diff-db555a627af01db05e34d4c1168821db5f9082ef958ef2e47cce01fd6f6c8f51R48-R63) [[2]](diffhunk://#diff-db555a627af01db05e34d4c1168821db5f9082ef958ef2e47cce01fd6f6c8f51R83-R86)
* Updated `main.cpp` to handle the `--hf` flag for `pull`, `run`, and `serve` commands, bypassing static model-list checks and invoking the new HuggingFace logic. [[1]](diffhunk://#diff-9b7f28f99932d75a1789e8f8bc4b11c25dfb9cff179685cacbbfe8add5656e95L502-R504) [[2]](diffhunk://#diff-9b7f28f99932d75a1789e8f8bc4b11c25dfb9cff179685cacbbfe8add5656e95L537-R541) [[3]](diffhunk://#diff-9b7f28f99932d75a1789e8f8bc4b11c25dfb9cff179685cacbbfe8add5656e95R612-R622) [[4]](diffhunk://#diff-9b7f28f99932d75a1789e8f8bc4b11c25dfb9cff179685cacbbfe8add5656e95R648-R658) [[5]](diffhunk://#diff-9b7f28f99932d75a1789e8f8bc4b11c25dfb9cff179685cacbbfe8add5656e95R681)

**Dynamic Model Management:**

* Extended `model_list` to support dynamic registration, lookup, and listing of HuggingFace models, including methods for registering, checking, and retrieving their paths and info. HuggingFace models are now included in listing and API responses. [[1]](diffhunk://#diff-9db690b5440a9576390707a262d1cad9cf2dd50723c10040a25252366bae268aR57-R63) [[2]](diffhunk://#diff-9db690b5440a9576390707a262d1cad9cf2dd50723c10040a25252366bae268aR147-R151) [[3]](diffhunk://#diff-9db690b5440a9576390707a262d1cad9cf2dd50723c10040a25252366bae268aL154-R172) [[4]](diffhunk://#diff-9db690b5440a9576390707a262d1cad9cf2dd50723c10040a25252366bae268aR198-R206) [[5]](diffhunk://#diff-9db690b5440a9576390707a262d1cad9cf2dd50723c10040a25252366bae268aR235-R246) [[6]](diffhunk://#diff-9db690b5440a9576390707a262d1cad9cf2dd50723c10040a25252366bae268aR255-R261) [[7]](diffhunk://#diff-9db690b5440a9576390707a262d1cad9cf2dd50723c10040a25252366bae268aL225-R290)

**Configuration Improvements:**

* Enhanced `LM_Config` to allow `config.json` to override the model name for xclbin lookup, supporting custom and branch-based snapshots.

These changes collectively enable seamless, user-friendly workflows for using HuggingFace models with the existing system, while maintaining backward compatibility and improving configurability.
```