### PR TITLE
feat(telemetry): add embedding token count usage

### DIFF
--- a/src/common/AutoEmbeddingModel/modeling_gemma_embedding.cpp
+++ b/src/common/AutoEmbeddingModel/modeling_gemma_embedding.cpp
@@ -18,6 +18,11 @@ void Gemma_Embedding::load_model(std::string model_path, json model_info, bool e
 }
 
 std::vector<float> Gemma_Embedding::embed(std::string& text, embedding_task_type_t task_type) {
+    size_t dummy_prompt_tokens;
+    return this->embed_with_usage(text, task_type, dummy_prompt_tokens);
+}
+
+std::vector<float> Gemma_Embedding::embed_with_usage(std::string& text, embedding_task_type_t task_type, size_t& prompt_tokens) {
     std::string task_prefix = this->_get_task_prefix(task_type);
     std::string full_text = "<bos>" + task_prefix + text + "<eos>";
     std::vector<int> tokens = this->tokenizer->encode(full_text);
@@ -26,10 +31,11 @@ std::vector<float> Gemma_Embedding::embed(std::string& text, embedding_task_type
         tokens.resize(2048);
         tokens[2047] = 1;
     }
+    prompt_tokens = tokens.size();
     
     buffer<bf16> y = this->embedding_model_impl->embed(tokens);
     std::vector<float> result(y.size());
-    for (int i = 0; i < y.size(); i++) {
+    for (size_t i = 0; i < y.size(); i++) {
         result[i] = static_cast<float>(y[i]);
     }
     return result;

--- a/src/include/AutoEmbeddingModel/auto_embedding_model.hpp
+++ b/src/include/AutoEmbeddingModel/auto_embedding_model.hpp
@@ -82,6 +82,23 @@ public:
 	
 	virtual void load_model(std::string model_path, json model_info, bool enable_preemption) {}
 	virtual std::vector<float> embed(std::string& text, embedding_task_type_t task_type) = 0;
+
+	/// \brief Embed the text and return prompt token count
+	/// \param text the text
+	/// \param task_type the task type
+	/// \param prompt_tokens [out] output variable to store the count of tokens processed
+	/// \return the embedding result vector
+	/// \note Subclasses should override this method to perform single-pass tokenization
+	/// and ensure model-specific formatting (e.g. prefixes/suffixes) is accounted for.
+	/// Default fallback implementation will tokenise raw text twice.
+	virtual std::vector<float> embed_with_usage(std::string& text, embedding_task_type_t task_type, size_t& prompt_tokens) {
+		if (tokenizer) {
+			prompt_tokens = tokenizer->encode(text).size();
+		} else {
+			prompt_tokens = 0;
+		}
+		return embed(text, task_type);
+	}
 };
 
 

--- a/src/include/AutoEmbeddingModel/modeling_gemma_embedding.hpp
+++ b/src/include/AutoEmbeddingModel/modeling_gemma_embedding.hpp
@@ -57,4 +57,5 @@ public:
 
     void load_model(std::string model_path, json model_info, bool enable_preemption = false) override;
     std::vector<float> embed(std::string& text, embedding_task_type_t task_type) override;
+    std::vector<float> embed_with_usage(std::string& text, embedding_task_type_t task_type, size_t& prompt_tokens) override;
 };

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -843,10 +843,13 @@ void RestHandler::handle_embeddings(const json& request,
         json response;
         if (this->embed) {
             json embedding_data = json::array();
+            size_t total_prompt_tokens = 0;
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
             for (size_t i = 0; i < inputs.size(); ++i) {
                 std::cout << "Embedding input[" << i << "]: " << "\n" << inputs[i] << std::endl;
-                std::vector<float> embedding_result = this->auto_embedding_engine->embed(inputs[i], embedding_task_type_t::task_query);
+                size_t prompt_tokens = 0;
+                std::vector<float> embedding_result = this->auto_embedding_engine->embed_with_usage(inputs[i], embedding_task_type_t::task_query, prompt_tokens);
+                total_prompt_tokens += prompt_tokens;
                 embedding_data.push_back({
                     {"object", "embedding"},
                     {"embedding", embedding_result},
@@ -862,8 +865,8 @@ void RestHandler::handle_embeddings(const json& request,
                 {"data", embedding_data},
                 {"model", model},
                 {"usage", {
-                    {"prompt_tokens", 0},
-                    {"total_tokens", 0}
+                    {"prompt_tokens", total_prompt_tokens},
+                    {"total_tokens", total_prompt_tokens}
                 }}
             };
         }

--- a/src/test/gemma_embedding/test.cpp
+++ b/src/test/gemma_embedding/test.cpp
@@ -113,13 +113,19 @@ int main(int argc, char* argv[]) {
     std::string text = "Alice's Adventures in Wonderland ALICE'S ADVENTURES IN WONDERLAND Lewis Carroll THE MILLENNIUM FULCRUM EDITION 3.0 CHAPTER I Down the Rabbit-HoleAlice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do:  once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, and what is the use of a book,'thought Alice without pictures or conversation?' So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her. There was nothing so VERY remarkable in that; nor did Alice think it so VERY much out of the way to hear the Rabbit say to itself, `Oh dear!  Oh dear!  I shall be late!'";
 
     time_utils::time_point start_time = time_utils::now();
-    auto y = embedding->embed(text, task_query);
+    size_t prompt_tokens = 0;
+    auto y = embedding->embed_with_usage(text, task_query, prompt_tokens);
     buffer<bf16> y_bf16(y.size());
     for (int i = 0; i < y.size(); i++){
         y_bf16[i] = (bf16)y[i];
     }
     time_utils::time_point end_time = time_utils::now();
     std::cout << "Time: " << time_utils::duration_ms(start_time, end_time).first << "ms" << std::endl;
+    std::cout << "Usage (prompt_tokens): " << prompt_tokens << std::endl;
+    if (prompt_tokens == 0) {
+        std::cerr << "Error: prompt_tokens is 0!" << std::endl;
+        return 1;
+    }
     utils::print_matrix(y_bf16, 128);
 
     buffer<bf16> ref_bf16 = buffer<bf16>(y_bf16.size());


### PR DESCRIPTION
This change introduces `embed_with_usage` to `AutoEmbeddingModel` to return prompt token counts. Implemented for `Gemma_Embedding`, avoiding double-tokenization, and update `RestHandler` to report total batch usage.

This change also updates standalone test suite to verify token counts.