### PR TITLE
fix: xclbin path finding

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -44,7 +44,7 @@ std::string find_model_list() {
         return exe_relative_path;
     }
 
-    // 4. Check current working directory
+    // Linux Portable
     if (std::filesystem::exists("model_list.json")) {
         return "model_list.json";
     }
@@ -56,7 +56,7 @@ std::string find_model_list() {
 std::string find_xclbin_path() {
     std::string xclbin_prefix = CMAKE_XCLBIN_PREFIX;
 
-    // 1. Check FLM_CONFIG_PATH environment variable
+    // Check FLM_CONFIG_PATH environment variable
     const char* env_path = std::getenv("FLM_XCLBIN_PATH");
     if (env_path && *env_path) {
         // Remove possible "/xclbins" or "/xclbins/" from the end of the path
@@ -76,16 +76,25 @@ std::string find_xclbin_path() {
         }
     }
 
-    // 2. Check current working directory
+#ifndef _WIN32
+    // Linux: Portable
     if (std::filesystem::exists("xclbins")) {
-        return "xclbins";
+        return ".";
     }
 
-    // 3. Check for install prefix
+    // Linux: install
     std::string installed_path = xclbin_prefix;
     if (std::filesystem::exists(installed_path)) {
         return installed_path;
     }
+#else
+    // Windows: Check relative to executable
+    std::string exe_dir = get_executable_directory();
+    std::string exe_relative_path = exe_dir;
+    if (std::filesystem::exists(exe_relative_path)) {
+        return exe_relative_path;
+    }
+#endif
 
     // If not found, throw an error
     throw std::runtime_error("xclbins not found. Please set FLM_XCLBIN_PATH or place it next to the executable.");

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -76,22 +76,15 @@ std::string find_xclbin_path() {
         }
     }
 
-    // 2. Check for install prefix
+    // 2. Check current working directory
+    if (std::filesystem::exists("xclbins")) {
+        return "xclbins";
+    }
+
+    // 3. Check for install prefix
     std::string installed_path = xclbin_prefix;
     if (std::filesystem::exists(installed_path)) {
         return installed_path;
-    }
-
-    // 3. Check relative to executable
-    std::string exe_dir = get_executable_directory();
-    std::string exe_relative_path = exe_dir;
-    if (std::filesystem::exists(exe_relative_path)) {
-        return exe_relative_path;
-    }
-
-    // 4. Check current working directory
-    if (std::filesystem::exists("xclbins")) {
-        return "xclbins";
     }
 
     // If not found, throw an error


### PR DESCRIPTION
Fix the `xclbin` search order in `find_xclbin_path()`:

1. `FLM_XCLBIN_PATH` environment variable
1. `xclbins/` in the current working directory
1. FLM install prefix (default: `/opt/fastflowlm/share/flm` on Linux)