### PR TITLE
docs: fix portable Linux build instructions and update Yang bio

### DIFF
--- a/docs/docs/install_lin.md
+++ b/docs/docs/install_lin.md
@@ -181,18 +181,18 @@ If `flm validate` passes but `flm run` fails with `No such device with index '0'
 
 #### Advanced Build Options
 
-**Static Build with Bundled XRT/XDNA**
+**Portable Build with Bundled XRT/FFmpeg**
 
-To build a fully static binary that bundles XRT and XDNA driver (no system XRT required):
+To build a portable distribution that bundles XRT and statically links FFmpeg (no system XRT required):
 
 ```sh
 cd src
-cmake --preset linux-static
+cmake --preset linux-portable
 cmake --build build -j$(nproc)
-sudo cmake --install build
+DESTDIR=$PWD/build/install cmake --install build
 ```
 
-This will automatically fetch and build XRT (v2.21.75) and XDNA driver from source if not found on your system. The resulting binary is fully self-contained and more portable.
+This builds FFmpeg and zlib statically, and uses system XRT if present—otherwise it automatically fetches and builds XRT (v2.21.75) and the XDNA driver from source. The bundled libraries are placed in `lib/` with `$ORIGIN` RPATH, so the resulting `flm` binary is self-contained and runs on machines without a system XRT install.
 
 ---
 

--- a/docs/docs/install_lin.md
+++ b/docs/docs/install_lin.md
@@ -181,7 +181,7 @@ If `flm validate` passes but `flm run` fails with `No such device with index '0'
 
 #### Advanced Build Options
 
-**Portable Build with Bundled XRT/FFmpeg**
+**Portable Build (Bundled XRT, Static FFmpeg)**
 
 To build a portable distribution that bundles XRT and statically links FFmpeg (no system XRT required):
 
@@ -192,7 +192,9 @@ cmake --build build -j$(nproc)
 DESTDIR=$PWD/build/install cmake --install build
 ```
 
-This builds FFmpeg and zlib statically, and uses system XRT if present—otherwise it automatically fetches and builds XRT (v2.21.75) and the XDNA driver from source. The bundled libraries are placed in `lib/` with `$ORIGIN` RPATH, so the resulting `flm` binary is self-contained and runs on machines without a system XRT install.
+This builds FFmpeg and zlib statically, and uses system XRT if present—otherwise it automatically fetches and builds XRT (v2.21.75) from source. Bundled shared libraries (XRT, FFTW) are placed in `lib/` with `$ORIGIN` RPATH, so the resulting `flm` binary runs on machines without a system XRT install.
+
+> **Note:** The XDNA userspace plugin (`libxrt_driver_xdna.so.2`) is *not* built by this preset—it must be provided by your system (e.g. the `libxrt-npu2` package). It is bundled into `lib/` only when present on the build machine; otherwise install it on the target. `patchelf` is also needed for RPATH patching; if it is missing the build succeeds but the step is skipped.
 
 ---
 

--- a/docs/linux-getting-started.md
+++ b/docs/linux-getting-started.md
@@ -150,9 +150,11 @@ cmake --build build -j$(nproc)
 DESTDIR=$PWD/build/install cmake --install build
 ```
 
-This builds FFmpeg and zlib statically and uses system XRT if present, otherwise it fetches and builds XRT (v2.21.75) plus the XDNA driver from source. Bundled libraries land in `lib/` with `$ORIGIN` RPATH, producing a `flm` binary you can relocate and run without installing XRT system-wide.
+This builds FFmpeg and zlib statically and uses system XRT if present, otherwise it fetches and builds XRT (v2.21.75) from source. Bundled shared libraries (XRT, FFTW) land in `lib/` with `$ORIGIN` RPATH, producing a `flm` binary you can relocate and run without installing XRT system-wide.
 
-`patchelf` is required for this preset (`sudo apt install patchelf`).
+> **Note:** The XDNA userspace plugin (`libxrt_driver_xdna.so.2`) is *not* built by this preset—it must come from your system (e.g. the `libxrt-npu2` package). When present on the build machine it is bundled into `lib/`; otherwise you must provide it on the target machine.
+
+Install `patchelf` (`sudo apt install patchelf`) so the bundled libraries get their `$ORIGIN` RPATH set. Without it the build still succeeds, but RPATH patching is skipped and the bundled libraries may not resolve when relocated.
 
 ---
 

--- a/docs/linux-getting-started.md
+++ b/docs/linux-getting-started.md
@@ -139,6 +139,21 @@ In short: if 1.1 firmware breaks probing on stock 6.19, do not keep forcing the 
    sudo cmake --install .
    ```
 
+### Portable Build
+
+To build a self-contained distribution that bundles XRT and statically links FFmpeg—so it runs on machines without a system XRT install—use the `linux-portable` preset:
+
+```sh
+cd src
+cmake --preset linux-portable
+cmake --build build -j$(nproc)
+DESTDIR=$PWD/build/install cmake --install build
+```
+
+This builds FFmpeg and zlib statically and uses system XRT if present, otherwise it fetches and builds XRT (v2.21.75) plus the XDNA driver from source. Bundled libraries land in `lib/` with `$ORIGIN` RPATH, producing a `flm` binary you can relocate and run without installing XRT system-wide.
+
+`patchelf` is required for this preset (`sudo apt install patchelf`).
+
 ---
 
 ## Validating NPU Setup

--- a/docs/team.md
+++ b/docs/team.md
@@ -49,7 +49,7 @@ sections:
         role: "Co-Founder"
         image: "/assets/kenqingyang.png"
         bio: |
-          Distinguished Engineering Professor · University of Rhode Island. With more than 30 years of experience in computer architecture and parallel processing, he is a serial entrepreneur who has successfully built four high-tech startups rooted in his research innovations—including VeloBit (acquired by Western Digital) and DapuStor (currently in the IPO process). 
+          Distinguished Engineering Professor · University of Rhode Island. With more than 30 years of experience in computer architecture and parallel processing, he is a serial entrepreneur who has successfully built four high-tech startups rooted in his research innovations—including VeloBit (acquired by Western Digital) and DapuStor (now publicly listed following its IPO). 
         links:
           - label: "URI profile"
             url: "https://web.uri.edu/ecbe/meet/qing-ken-yang/"

--- a/src/README.md
+++ b/src/README.md
@@ -71,13 +71,17 @@ FastFlowLM can be built as a portable distribution with XRT bundled and FFmpeg s
 # Use the linux-portable preset
 cmake --preset linux-portable
 cmake --build build -j$(nproc)
+# The portable layout (lib/ bundling + wrapper) is produced at install time
+DESTDIR=$PWD/build/install cmake --install build
 ```
 
 This will:
 1. Check if XRT is installed via pkg-config
 2. If not found, automatically fetch XRT (v2.21.75) from source and build it
 3. Build FFmpeg (v7.1) and zlib as static libraries
-4. Bundle the shared libraries into `lib/` with `$ORIGIN` RPATH
+4. On install, bundle the shared libraries into `lib/` with `$ORIGIN` RPATH (requires `patchelf`)
+
+> **Note:** The `cmake --install` step is what bundles the shared libraries into `lib/` and installs the wrapper. Without it you get a plain build, not the self-contained distribution.
 
 **What gets statically linked:**
 - ✅ FFmpeg (libavformat, libavcodec, libavutil, libswscale, libswresample)
@@ -86,9 +90,9 @@ This will:
 **What gets bundled (dynamic, in `lib/`):**
 - XRT (Xilinx Runtime)
 - FFTW (libfftw3)
+- XDNA driver plugin (`libxrt_driver_xdna.so.2`) — **only if present on the build machine**; it is not built by this preset and must be provided by your system (e.g. `libxrt-npu2`)
 
-**What remains dynamic:**
-- XDNA driver plugin (runtime plugin - see below)
+**What remains dynamic (from the target system):**
 - Model-specific libraries (llama_npu, qwen_npu, etc.)
 - System libraries (libc, libm, etc.)
 
@@ -98,6 +102,7 @@ This will:
 # Enable portable build manually
 cmake --preset linux-default -DFLM_PORTABLE_BUILD=ON
 cmake --build build -j$(nproc)
+DESTDIR=$PWD/build/install cmake --install build
 ```
 
 **Customizing source versions:**

--- a/src/README.md
+++ b/src/README.md
@@ -61,29 +61,31 @@ cmake --build build --target check_dependencies
 
 **Note:** Some custom libraries (XRT, NPU libraries) may still require DLLs if static versions aren't available.
 
-### Static Build (Portable Binary)
+### Portable Build (Self-Contained Binary)
 
-FastFlowLM can be built as a portable static binary with XRT and FFmpeg bundled in. This eliminates the need for system dependencies and creates a truly self-contained executable.
+FastFlowLM can be built as a portable distribution with XRT bundled and FFmpeg statically linked. This eliminates the need for system dependencies and creates a self-contained executable.
 
-**Simple static build:**
+**Simple portable build:**
 
 ```bash
-# Use the linux-static preset
-cmake --preset linux-static
+# Use the linux-portable preset
+cmake --preset linux-portable
 cmake --build build -j$(nproc)
 ```
 
 This will:
-1. Check if XRT and FFmpeg are installed via pkg-config
-2. If not found, automatically fetch from source:
-   - XRT (v2.21.75)
-   - FFmpeg (v7.1)
-3. Build both as static libraries
-4. Link them into the flm binary
+1. Check if XRT is installed via pkg-config
+2. If not found, automatically fetch XRT (v2.21.75) from source and build it
+3. Build FFmpeg (v7.1) and zlib as static libraries
+4. Bundle the shared libraries into `lib/` with `$ORIGIN` RPATH
 
 **What gets statically linked:**
-- ✅ XRT (Xilinx Runtime)
 - ✅ FFmpeg (libavformat, libavcodec, libavutil, libswscale, libswresample)
+- ✅ zlib
+
+**What gets bundled (dynamic, in `lib/`):**
+- XRT (Xilinx Runtime)
+- FFTW (libfftw3)
 
 **What remains dynamic:**
 - XDNA driver plugin (runtime plugin - see below)
@@ -93,15 +95,15 @@ This will:
 **Manual options:**
 
 ```bash
-# Enable static build manually
-cmake --preset linux-default -DFLM_STATIC_BUILD=ON
+# Enable portable build manually
+cmake --preset linux-default -DFLM_PORTABLE_BUILD=ON
 cmake --build build -j$(nproc)
 ```
 
 **Customizing source versions:**
 
 ```bash
-cmake --preset linux-static \
+cmake --preset linux-portable \
   -DXRT_GIT_TAG=2.21.75 \
   -DFFMPEG_GIT_TAG=n7.1
 cmake --build build -j$(nproc)


### PR DESCRIPTION
## Summary
- **Fix portable Linux build docs.** The install guides pointed users at a `linux-static` preset and `FLM_STATIC_BUILD` option that **do not exist** — the real names are `linux-portable` / `FLM_PORTABLE_BUILD` (see `src/CMakePresets.json` and `src/CMakeLists.txt`). Following the old docs would fail immediately.
- **Document the portable build** in the top-level Linux getting-started guide, so users can actually build a self-contained `flm`.
- **Update Ken Qing Yang's bio** — DapuStor has completed its IPO (was "currently in the IPO process").

## Changes
- **docs/docs/install_lin.md** — corrected the advanced-build section to `linux-portable`, added the install/DESTDIR step, and clarified what gets bundled vs. statically linked.
- **docs/linux-getting-started.md** — added a "Portable Build" subsection (correct preset, install step, `patchelf` prerequisite).
- **src/README.md** — renamed the "Static Build" section to "Portable Build", fixed all `linux-static` → `linux-portable` and `FLM_STATIC_BUILD` → `FLM_PORTABLE_BUILD`, and corrected the bundled-vs-static breakdown (XRT/FFTW bundled dynamic; FFmpeg/zlib static).
- **docs/team.md** — Yang's bio now reads "DapuStor (now publicly listed following its IPO)".

## Notes
- Matches how CI builds the portable artifact in `.github/workflows/debian-portable.yml`.
- I have not run the `linux-portable` build locally on this box; the instructions mirror the CI workflow and the CMake preset definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)