### PR TITLE
feat: add more levels for qwen image resize

### DIFF
--- a/src/common/AutoModel/modeling_qwen2vl_image.cpp
+++ b/src/common/AutoModel/modeling_qwen2vl_image.cpp
@@ -30,6 +30,18 @@ qwen2vl_image_t Qwen2VL::load_image(const std::string& filename) {
             case 4:
                 max_height = 1440;
                 break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
+                break;
             default:
                 max_height = decoded.height; // no resizing
                 break;
@@ -86,6 +98,18 @@ qwen2vl_image_t Qwen2VL::load_image_base64(const std::string& base64_string) {
                 break;
             case 4:
                 max_height = 1440;
+                break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
                 break;
             default:
                 max_height = decoded.height; // no resizing

--- a/src/common/AutoModel/modeling_qwen3_5vl_image.cpp
+++ b/src/common/AutoModel/modeling_qwen3_5vl_image.cpp
@@ -29,6 +29,19 @@ qwen3_5vl_image_t Qwen3_5VL::load_image(const std::string& filename) {
                 break;
             case 4:
                 max_height = 1440;
+                break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
+                break;
             default:
                 max_height = decoded.height; // no resizing
                 break;
@@ -84,6 +97,18 @@ qwen3_5vl_image_t Qwen3_5VL::load_image_base64(const std::string& base64_string)
                 break;
             case 4:
                 max_height = 1440;
+                break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
                 break;
             default:
                 max_height = decoded.height; // no resizing

--- a/src/common/AutoModel/modeling_qwen3_6_moe_image.cpp
+++ b/src/common/AutoModel/modeling_qwen3_6_moe_image.cpp
@@ -30,6 +30,19 @@ qwen3_6_moe_image_t Qwen3_6_MOE::load_image(const std::string& filename) {
                 break;
             case 4:
                 max_height = 1440;
+                break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
+                break;
             default:
                 max_height = decoded.height; // no resizing
                 break;
@@ -87,6 +100,18 @@ qwen3_6_moe_image_t Qwen3_6_MOE::load_image_base64(const std::string& base64_str
                 break;
             case 4:
                 max_height = 1440;
+                break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
                 break;
             default:
                 max_height = decoded.height; // no resizing

--- a/src/common/AutoModel/modeling_qwen3vl_image.cpp
+++ b/src/common/AutoModel/modeling_qwen3vl_image.cpp
@@ -29,6 +29,19 @@ qwen3vl_image_t Qwen3VL::load_image(const std::string& filename) {
                 break;
             case 4:
                 max_height = 1440;
+                break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
+                break;
             default:
                 max_height = decoded.height; // no resizing
                 break;
@@ -84,6 +97,18 @@ qwen3vl_image_t Qwen3VL::load_image_base64(const std::string& base64_string) {
                 break;
             case 4:
                 max_height = 1440;
+                break;
+            case 5:
+                max_height = 2160;
+                break;
+            case 6:
+                max_height = 2880;
+                break;
+            case 7:
+                max_height = 3240;
+                break;
+            case 8:
+                max_height = 4320;
                 break;
             default:
                 max_height = decoded.height; // no resizing

--- a/src/include/AutoModel/modeling_qwen2vl.hpp
+++ b/src/include/AutoModel/modeling_qwen2vl.hpp
@@ -80,6 +80,14 @@ public:
                     target_size = 1080;
                 } else if (this->image_pre_resize <= 4) {
                     target_size = 1440;
+                } else if (this->image_pre_resize <= 5) {
+                    target_size = 2160;
+                } else if (this->image_pre_resize <= 6) {
+                    target_size = 2880;
+                } else if (this->image_pre_resize <= 7) {
+                    target_size = 3240;
+                } else if (this->image_pre_resize <= 8) {
+                    target_size = 4320;
                 } else {
                     this->image_pre_resize = 0;
                     target_size = 0;

--- a/src/include/AutoModel/modeling_qwen3_5vl.hpp
+++ b/src/include/AutoModel/modeling_qwen3_5vl.hpp
@@ -120,6 +120,14 @@ public:
                     target_size = 1080;
                 } else if (this->image_pre_resize <= 4) {
                     target_size = 1440;
+                } else if (this->image_pre_resize <= 5) {
+                    target_size = 2160;
+                } else if (this->image_pre_resize <= 6) {
+                    target_size = 2880;
+                } else if (this->image_pre_resize <= 7) {
+                    target_size = 3240;
+                } else if (this->image_pre_resize <= 8) {
+                    target_size = 4320;
                 } else {
                     this->image_pre_resize = 0;
                     target_size = 0;

--- a/src/include/AutoModel/modeling_qwen3_6_moe.hpp
+++ b/src/include/AutoModel/modeling_qwen3_6_moe.hpp
@@ -120,6 +120,14 @@ public:
                     target_size = 1080;
                 } else if (this->image_pre_resize <= 4) {
                     target_size = 1440;
+                } else if (this->image_pre_resize <= 5) {
+                    target_size = 2160;
+                } else if (this->image_pre_resize <= 6) {
+                    target_size = 2880;
+                } else if (this->image_pre_resize <= 7) {
+                    target_size = 3240;
+                } else if (this->image_pre_resize <= 8) {
+                    target_size = 4320;
                 } else {
                     this->image_pre_resize = 0;
                     target_size = 0;

--- a/src/include/AutoModel/modeling_qwen3vl.hpp
+++ b/src/include/AutoModel/modeling_qwen3vl.hpp
@@ -83,6 +83,14 @@ public:
                     target_size = 1080;
                 } else if (this->image_pre_resize <= 4) {
                     target_size = 1440;
+                } else if (this->image_pre_resize <= 5) {
+                    target_size = 2160;
+                } else if (this->image_pre_resize <= 6) {
+                    target_size = 2880;
+                } else if (this->image_pre_resize <= 7) {
+                    target_size = 3240;
+                } else if (this->image_pre_resize <= 8) {
+                    target_size = 4320;
                 } else {
                     this->image_pre_resize = 0;
                     target_size = 0;

--- a/src/include/utils/vm_args.hpp
+++ b/src/include/utils/vm_args.hpp
@@ -47,7 +47,7 @@ inline void print_help(po::options_description& general) {
     std::cout << "\tflm serve llama3.2:1b --cors 0" << std::endl;
     std::cout << "\tflm serve llama3.2:1b --asr 1" << std::endl;
     std::cout << "\tflm serve llama3.2:1b --embed 1" << std::endl;
-    std::cout << "\tflm serve qwen3vl-it:4b --resize 1 (0: original size, 1: height = 480, 2: height = 720, 3: height = 1080)" << std::endl;
+    std::cout << "\tflm serve qwen3vl-it:4b --img-pre-resize 1" << std::endl;
     std::cout << "\tflm list" << std::endl;
     std::cout << "\tflm list --quiet" << std::endl;
     std::cout << "\tflm list --filter installed" << std::endl;
@@ -90,7 +90,7 @@ bool parse_options(int argc, char *argv[], program_args_t& parsed_args) {
             ("prefill-chunk-len,pcl", po::value<int>(&parsed_args.prefill_chunk_len)->default_value(-1),
              "Set prefill chunk length")
             ("img-pre-resize,r", po::value<int>(&parsed_args.img_pre_resize)->default_value(2),
-             "Pre-resize the image, 0: original size, 1: height = 480, 2: height = 720, 3: height = 1080, 4: height = 1440")
+             "Pre-resize the image, 0: original size, 1: height = 480, 2: height = 720, 3: height = 1080, 4: height = 1440, 5: height = 2160, 6: height = 2880, 7: height = 3240, 8: height = 4320")
             ("socket,s", po::value<size_t>(&parsed_args.max_socket_connections)->default_value(10),
             "Set the maximum number of socket connections allowed (for serve command)")
             ("q-len,q", po::value<size_t>(&parsed_args.max_npu_queue)->default_value(10),


### PR DESCRIPTION
Usage:

`flm serve -r <img-pre-resize_level>`

0: original size,
1: height = 480, 
2: height = 720, 
3: height = 1080, 
4: height = 1440, 
5: height = 2160, 
6: height = 2880, 
7: height = 3240, 
8: height = 4320