### PR TITLE
ci: strip debug symbols from flm-real binary in portable build

### DIFF
--- a/.github/workflows/debian-portable.yml
+++ b/.github/workflows/debian-portable.yml
@@ -69,6 +69,10 @@ jobs:
         mv install/opt/fastflowlm/flm-wrapper.sh install/opt/fastflowlm/flm
         chmod +x install/opt/fastflowlm/flm
 
+        # Strip debug symbols to reduce binary size (111MB → 33MB)
+        # --strip-debug removes debug info while keeping stack trace capability
+        strip --strip-debug install/opt/fastflowlm/flm-real
+
     - name: Create portable tarball
       env:
         VERSION: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
## Problem

The `flm-real` binary size on Linux is **111MB** due to debug symbols being included in the release build. 

- `strip --strip-debug` → **33MB**
- `strip` (no args) → **29MB**

## Fix

Added `strip --strip-debug` to the portable build workflow after installing the binary. This removes debug symbols while preserving stack trace capability.

## Notes

- Users who need debug symbols can build from source (CMake build isn't stripped)
- The stripped binary is sufficient for production use and significantly reduces download/install size

Fixes #639