### PR TITLE
Improve model pulling/checking

### DIFF
--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -21,33 +21,33 @@ ModelDownloader::ModelDownloader(model_list& models)
 /// \brief Check if the model is downloaded
 /// \param model_tag the model tag
 /// \return true if the model is downloaded, false otherwise
-bool ModelDownloader::is_model_downloaded(const std::string& model_tag, bool sub_process_mode, bool fast_check) {
+ModelDownloader::ModelStatus ModelDownloader::is_model_downloaded(const std::string& model_tag, bool sub_process_mode, bool fast_check) {
     auto missing_files = get_missing_files(model_tag);
     bool is_config_file_missing = std::find(missing_files.begin(), missing_files.end(), "config.json") != missing_files.end();
+    ModelStatus modelstatus = ModelStatus::Missing;
+
     if (!is_config_file_missing) {
-        if (!check_model_compatibility(model_tag, sub_process_mode)) {
-            if (!sub_process_mode)
-                header_print("FLM", "Model " + model_tag + " is not compatible with the current FLM version. ");
-            // Fast path: skip the expensive HF metadata fetch + per-file hash
-            // verification. Caller (e.g. `flm list`) only needs the boolean
-            // status; cleanup can happen later on `pull` / `check`.
-            if (fast_check) {
-                return false;
+        // header_print("DEBUG", "Are you kidding me?");
+        modelstatus = check_model_compatibility(model_tag, sub_process_mode);
+
+        if (modelstatus == ModelStatus::Outdated) {
+            if (!fast_check) {
+                header_print("FLM", "Checking outdated files...");
+                verify_and_clean_files(model_tag, sub_process_mode);
             }
-            // Instead of removing all files wholesale, verify each file against
-            // HuggingFace metadata and remove only corrupted ones (same logic
-            // as check_model). Files that pass verification can be reused.
-            verify_and_clean_files(model_tag, sub_process_mode);
-            return false;
         }
+        else if (modelstatus == ModelStatus::Incompatible) {
+        }
+        else if (modelstatus == ModelStatus::Ready) {
+        }        
     }
-    return missing_files.empty();
+    return modelstatus;
 }
 
 /// \brief Check if the model is compatible with the current FLM version
 /// \param model_tag the model tag
 /// \return true if the model is compatible, false otherwise
-bool ModelDownloader::check_model_compatibility(const std::string& model_tag, bool sub_process_mode) {
+ModelDownloader::ModelStatus ModelDownloader::check_model_compatibility(const std::string& model_tag, bool sub_process_mode) {
     auto [new_model_tag, model_info] = supported_models.get_model_info(model_tag);
     LM_Config config;
     config.from_pretrained(this->supported_models.get_model_path(new_model_tag));
@@ -62,27 +62,20 @@ bool ModelDownloader::check_model_compatibility(const std::string& model_tag, bo
     uint32_t local_version_u32 = l_l * 1000000 + m_l * 1000 + r_l;
     uint32_t required_version_u32 = l_r * 1000000 + m_r * 1000 + r_r;
     uint32_t flm_version_u32 = l_f * 1000000 + m_f * 1000 + r_f;
-    bool is_future_version = false;
-    if (local_version_u32 > flm_version_u32) {
-        is_future_version = true;
-    }
-    bool is_compatible = true;
-    if (local_version_u32 < required_version_u32) {
-        is_compatible = false;
-    }
+
     if (!sub_process_mode) {
-        if (is_future_version) {
-            header_print("WARNING", "Local model version: " + flm_version + " > " + __FLM_VERSION__);
-            header_print("WARNING", "This model may not be compatible with the current FLM version.");
+        if (local_version_u32 > flm_version_u32) {
+            header_print("WARNING", "Local model " + model_tag + " version: " + flm_version + " > " + __FLM_VERSION__);
             header_print("WARNING", "Please update FLM to the latest version.");
-            exit(0);
+            return ModelStatus::Incompatible;
         }
-        if (!is_compatible) {
-            header_print("FLM", "Local model " + model_tag + " version: " + flm_version + " < " + flm_min_version);
-            return false;
+        if (local_version_u32 < required_version_u32) {
+            header_print("WARNING", "Local model " + model_tag + " version: " + flm_version + " < " + flm_min_version);
+            header_print("FLM", "Re-pulling latest model...");
+            return ModelStatus::Outdated;
         }
     }
-    return is_compatible;
+    return  ModelStatus::Ready;
 }
 /// \brief Pull the model
 /// \param model_tag the model tag
@@ -98,18 +91,22 @@ bool ModelDownloader::pull_model(const std::string& model_tag, bool use_modelsco
         header_print("FLM", "Pulling model from " + model_server + "...");
         header_print("FLM", "Model: " + new_model_tag);
         header_print("FLM", "Name: " + model_name);
-        
-        // Check if model is already downloaded
-        if (!force_redownload && is_model_downloaded(new_model_tag)) {
-            header_print("FLM", "Model already downloaded. Use --force to re-download.");
-            return true;
-        }
 
-        // If force, verify existing files and remove only corrupted ones,
-        // instead of wiping the whole model directory. Files that pass
-        // verification will be reused; missing/corrupted ones get re-downloaded.
-        if (force_redownload) {
-            verify_and_clean_files(new_model_tag);
+        ModelDownloader::ModelStatus status = is_model_downloaded(new_model_tag);
+        switch (status) {
+            case ModelStatus::Ready:
+                if (!force_redownload) {
+                    header_print("FLM", "Model already downloaded. Use --force to re-download.");
+                    return true;
+                }
+                verify_and_clean_files(new_model_tag, use_modelscope);
+                break;
+            case ModelStatus::Missing:
+                break;
+            case ModelStatus::Outdated:
+                break;
+            case ModelStatus::Incompatible:
+                return true;
         }
         
         // Get missing files
@@ -304,16 +301,16 @@ std::pair<nlohmann::json, float> ModelDownloader::build_download_list(const std:
         
         nlohmann::json hf_model_infos;
         // GET HF api/models
-        if (modelscope == 0) {
-            std::string hf_response = download_utils::download_string(file_url);
-            hf_model_infos = nlohmann::json::parse(hf_response);
-        }
-        else {
-            std::string model_info_path = utils::find_model_info();
-            std::ifstream model_info_file(model_info_path);
-            nlohmann::json model_info_json = nlohmann::json::parse(model_info_file);
-            hf_model_infos = model_info_json.at(new_model_tag);
-        }
+        // if (modelscope == 0) {
+        //     std::string hf_response = download_utils::download_string(file_url);
+        //     hf_model_infos = nlohmann::json::parse(hf_response);
+        // }
+        // else {
+        std::string model_info_path = utils::find_model_info();
+        std::ifstream model_info_file(model_info_path);
+        nlohmann::json model_info_json = nlohmann::json::parse(model_info_file);
+        hf_model_infos = model_info_json.at(new_model_tag);
+        // }
 
         for (const auto& filename : model_files) {
             auto it = std::find_if(
@@ -424,18 +421,24 @@ bool ModelDownloader::check_model(const std::string& model_tag, bool use_modelsc
     auto [new_model_tag, model_info] = supported_models.get_model_info(model_tag);
     header_print("FLM", "Checking model: " + new_model_tag + "...\n");
 
-    if (!is_model_downloaded(new_model_tag, sub_process_mode)) {
-        header_print("FLM", "Model not exist or not compatible: " + new_model_tag);
-        header_print("FLM", "Please use `flm pull " + new_model_tag + "` to download the model.");
-        return true;
-    }
-    else {
-        bool ok = verify_and_clean_files(new_model_tag, use_modelscope, sub_process_mode);
-        if (!ok) {
-            header_print("FLM", "Model check completed with errors. Please use `flm pull " + new_model_tag + "` to re-download corrupted files.");
-        }
-        else {
-            header_print("FLM", "Model check completed successfully. All files are present and compatible.");
+    ModelStatus status = is_model_downloaded(new_model_tag, sub_process_mode);
+    switch (status) {
+        case ModelStatus::Missing:
+            header_print("FLM", "Model not found: " + new_model_tag);
+            header_print("FLM", "Use `flm pull " + new_model_tag + "` to download it.");
+            return true;
+        case ModelStatus::Incompatible:
+            header_print("FLM", "Model is incompatible with this version of FastFlowLM: " + new_model_tag);
+            header_print("FLM", "Use `flm pull " + new_model_tag + "` to re-download it.");
+            return true;
+        case ModelStatus::Outdated:
+        case ModelStatus::Ready: {
+            bool ok = verify_and_clean_files(new_model_tag, use_modelscope, sub_process_mode);
+            if (!ok)
+                header_print("FLM", "Model check completed with errors. Use `flm pull " + new_model_tag + "` to re-download corrupted files.");
+            else
+                header_print("FLM", "Model check completed successfully. All files are present and compatible.");
+            return true;
         }
     }
     return true;
@@ -456,16 +459,16 @@ bool ModelDownloader::verify_and_clean_files(const std::string& model_tag, bool 
 
         nlohmann::json hf_model_infos;
         // GET HF api/models
-        if (use_modelscope == 0) {
-            std::string hf_response = download_utils::download_string(file_url);
-            hf_model_infos = nlohmann::json::parse(hf_response);
-        }
-        else {
-            std::string model_info_path = utils::find_model_info();
-            std::ifstream model_info_file(model_info_path);
-            nlohmann::json model_info_json = nlohmann::json::parse(model_info_file);
-            hf_model_infos = model_info_json.at(new_model_tag);
-        }
+        // if (use_modelscope == 0) {
+        //     std::string hf_response = download_utils::download_string(file_url);
+        //     hf_model_infos = nlohmann::json::parse(hf_response);
+        // }
+        // else {
+        std::string model_info_path = utils::find_model_info();
+        std::ifstream model_info_file(model_info_path);
+        nlohmann::json model_info_json = nlohmann::json::parse(model_info_file);
+        hf_model_infos = model_info_json.at(new_model_tag);
+        // }
 
         for (const auto& filename : model_files) {
             if (!sub_process_mode) {

--- a/src/pull/model_downloader.cpp
+++ b/src/pull/model_downloader.cpp
@@ -27,7 +27,6 @@ ModelDownloader::ModelStatus ModelDownloader::is_model_downloaded(const std::str
     ModelStatus modelstatus = ModelStatus::Missing;
 
     if (!is_config_file_missing) {
-        // header_print("DEBUG", "Are you kidding me?");
         modelstatus = check_model_compatibility(model_tag, sub_process_mode);
 
         if (modelstatus == ModelStatus::Outdated) {
@@ -36,10 +35,11 @@ ModelDownloader::ModelStatus ModelDownloader::is_model_downloaded(const std::str
                 verify_and_clean_files(model_tag, sub_process_mode);
             }
         }
-        else if (modelstatus == ModelStatus::Incompatible) {
+        else if (modelstatus == ModelStatus::Ready && !missing_files.empty()) {
+            // config.json is present and the version check passed, but other
+            // files (e.g. weights) are still missing.
+            modelstatus = ModelStatus::Missing;
         }
-        else if (modelstatus == ModelStatus::Ready) {
-        }        
     }
     return modelstatus;
 }
@@ -63,19 +63,21 @@ ModelDownloader::ModelStatus ModelDownloader::check_model_compatibility(const st
     uint32_t required_version_u32 = l_r * 1000000 + m_r * 1000 + r_r;
     uint32_t flm_version_u32 = l_f * 1000000 + m_f * 1000 + r_f;
 
-    if (!sub_process_mode) {
-        if (local_version_u32 > flm_version_u32) {
+    if (local_version_u32 > flm_version_u32) {
+        if (!sub_process_mode) {
             header_print("WARNING", "Local model " + model_tag + " version: " + flm_version + " > " + __FLM_VERSION__);
             header_print("WARNING", "Please update FLM to the latest version.");
-            return ModelStatus::Incompatible;
         }
-        if (local_version_u32 < required_version_u32) {
+        return ModelStatus::Incompatible;
+    }
+    if (local_version_u32 < required_version_u32) {
+        if (!sub_process_mode) {
             header_print("WARNING", "Local model " + model_tag + " version: " + flm_version + " < " + flm_min_version);
             header_print("FLM", "Re-pulling latest model...");
-            return ModelStatus::Outdated;
         }
+        return ModelStatus::Outdated;
     }
-    return  ModelStatus::Ready;
+    return ModelStatus::Ready;
 }
 /// \brief Pull the model
 /// \param model_tag the model tag

--- a/src/pull/model_downloader.hpp
+++ b/src/pull/model_downloader.hpp
@@ -17,6 +17,9 @@
 
 class ModelDownloader {
 public:
+
+    enum class ModelStatus { Ready, Missing, Outdated,  Incompatible};
+
     ModelDownloader(model_list& models);
     
     // Check if model is already downloaded.
@@ -24,7 +27,7 @@ public:
     // are checked; no HuggingFace metadata is fetched and no per-file hash
     // verification / cleanup is performed. Use this for cheap status queries
     // such as `flm list`.
-    bool is_model_downloaded(const std::string& model_tag, bool sub_process_mode=0, bool fast_check=false);
+    ModelStatus is_model_downloaded(const std::string& model_tag, bool sub_process_mode=0, bool fast_check=false);
     
     // Download model files if not present
     bool pull_model(const std::string& model_tag, bool use_modelscope = false, bool force_redownload = false);
@@ -59,7 +62,7 @@ private:
     std::pair<nlohmann::json, float> build_download_list(const std::string& model_tag, bool modelscope=0);
 
     // bool check_model_compatibility(const std::string& model_tag);
-    bool check_model_compatibility(const std::string& model_tag, bool sub_process_mode=0);
+    ModelStatus check_model_compatibility(const std::string& model_tag, bool sub_process_mode=0);
 
     // Verify per-file integrity against HuggingFace metadata and remove any
     // corrupted files. Returns true if all files passed verification.

--- a/src/runner/runner.cpp
+++ b/src/runner/runner.cpp
@@ -56,8 +56,15 @@ Runner::Runner(model_list& supported_models, ModelDownloader& downloader, progra
     
     this->tag = auto_model.first;
 
-    if (!this->downloader.is_model_downloaded(this->tag)) {
-        this->downloader.pull_model(this->tag, this->modelscope);
+    switch (this->downloader.is_model_downloaded(this->tag)) {
+        case ModelDownloader::ModelStatus::Ready:
+            break;
+        case ModelDownloader::ModelStatus::Outdated:
+        case ModelDownloader::ModelStatus::Missing:
+            this->downloader.pull_model(this->tag, this->modelscope);
+            break;
+        case ModelDownloader::ModelStatus::Incompatible:
+            exit(EXIT_FAILURE);
     }
     auto [new_tag, model_info] = this->supported_models.get_model_info(this->tag);
     this->asr_supported = model_info.contains("asr") && model_info["asr"];
@@ -99,8 +106,16 @@ Runner::Runner(model_list& supported_models, ModelDownloader& downloader, progra
         {
             header_print("FLM", "The loaded model does not support ASR. Loading default Whisper model for ASR...");
             std::string whisper_tag = "whisper-v3:turbo";
-            if (!this->downloader.is_model_downloaded(whisper_tag)) {
-                this->downloader.pull_model(whisper_tag, this->modelscope);
+            switch (this->downloader.is_model_downloaded(whisper_tag)) {
+                case ModelDownloader::ModelStatus::Ready:
+                    break;
+                case ModelDownloader::ModelStatus::Outdated:
+                case ModelDownloader::ModelStatus::Missing:
+                    this->downloader.pull_model(whisper_tag, this->modelscope);
+                    break;
+                case ModelDownloader::ModelStatus::Incompatible:
+                    header_print("ERROR", "Whisper is incompatible with this version of FastFlowLM, skipping... ");
+                    return;
             }
             this->whisper_engine = std::make_unique<Whisper>(&this->npu_device_inst);
             auto [new_whisper_tag, whisper_model_info] = this->supported_models.get_model_info(whisper_tag);
@@ -109,7 +124,7 @@ Runner::Runner(model_list& supported_models, ModelDownloader& downloader, progra
                 this->whisper_engine->load_model(whisper_model_path, whisper_model_info, this->preemption);
             }
             catch (const std::exception& e) {
-                header_print("ERROR", "Failed to load ASR model: " + std::string(e.what()));
+                header_print("WARNING", "Failed to load ASR model: " + std::string(e.what()));
                 exit(EXIT_FAILURE);
             }
         }
@@ -204,13 +219,13 @@ void Runner::run() {
                 std::cout << "Models:" << std::endl;
                 nlohmann::json models = supported_models.get_all_models();
                 for (const auto& model : models["models"]) {
-                    bool is_present = downloader.is_model_downloaded(model["name"].get<std::string>());
-                    std::cout << "  - " << model["name"].get<std::string>();
-                    if (is_present){
-                        std::cout << " ✅";
-                    }
-                    else{
-                        std::cout << " ⏬";
+                    std::string name = model["name"].get<std::string>();
+                    std::cout << "  - " << name;
+                    switch (downloader.is_model_downloaded(name)) {
+                        case ModelDownloader::ModelStatus::Ready:        std::cout << " ✅"; break;
+                        case ModelDownloader::ModelStatus::Missing:      std::cout << " ⏬"; break;
+                        case ModelDownloader::ModelStatus::Outdated:     std::cout << " ⚠️"; break;
+                        case ModelDownloader::ModelStatus::Incompatible: std::cout << " ⚠️"; break;
                     }
                     std::cout << std::endl;
                 }
@@ -414,8 +429,16 @@ void Runner::cmd_load(std::vector<std::string>& input_list) {
     if (model_name != this->tag) {
         this->tag = model_name;
 
-        if (!this->downloader.is_model_downloaded(this->tag)) {
-            this->downloader.pull_model(this->tag, this->modelscope);
+        switch (this->downloader.is_model_downloaded(this->tag)) {
+            case ModelDownloader::ModelStatus::Ready:
+                break;
+            case ModelDownloader::ModelStatus::Outdated:
+            case ModelDownloader::ModelStatus::Missing:
+                this->downloader.pull_model(this->tag, this->modelscope);
+                break;
+            case ModelDownloader::ModelStatus::Incompatible:
+                header_print("ERROR", "Model is incompatible with this version of FastFlowLM: " + this->tag);
+                exit(EXIT_FAILURE);
         }
         auto_chat_engine.reset();
         if(model_name=="gpt-oss:20b")

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -387,9 +387,16 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
         std::pair<std::string, std::unique_ptr<AutoModel>> auto_model = get_auto_model(ensure_tag, this->supported_models, &this->npu_device_inst);
         auto_chat_engine = std::move(auto_model.second);
         ensure_tag = auto_model.first;
-        if (!downloader.is_model_downloaded(ensure_tag)) {
-            downloader.pull_model(ensure_tag, this->modelscope);
-        }
+        switch (downloader.is_model_downloaded(ensure_tag)) {
+            case ModelDownloader::ModelStatus::Ready:
+                break;
+            case ModelDownloader::ModelStatus::Outdated:
+            case ModelDownloader::ModelStatus::Missing:
+                downloader.pull_model(ensure_tag, this->modelscope);
+                break;
+            case ModelDownloader::ModelStatus::Incompatible:
+                return false;
+            }
         auto [new_ensure_tag, model_info] = supported_models.get_model_info(ensure_tag);
         auto_chat_engine->configure_parameter("img_pre_resize", this->img_pre_resize);
         try {
@@ -417,8 +424,16 @@ bool RestHandler::ensure_model_loaded(const std::string& model_tag) {
 void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
     std::string ensure_tag = model_tag;
-    if (!downloader.is_model_downloaded(ensure_tag)) {
-        downloader.pull_model(ensure_tag, modelscope);
+    switch (downloader.is_model_downloaded(ensure_tag)) {
+        case ModelDownloader::ModelStatus::Ready:
+            break;
+        case ModelDownloader::ModelStatus::Outdated:
+        case ModelDownloader::ModelStatus::Missing:
+            downloader.pull_model(ensure_tag, modelscope);
+            break;
+        case ModelDownloader::ModelStatus::Incompatible:
+            header_print("ERROR", "Whisper is incompatible with this version of FastFlowLM, skipping... ");
+            return;
     }
     this->whisper_engine = std::make_unique<Whisper>(&this->npu_device_inst);
     auto [new_ensure_tag, whisper_model_info] = this->supported_models.get_model_info(ensure_tag);
@@ -440,8 +455,16 @@ void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
 void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
 #ifndef FASTFLOWLM_LINUX_LIMITED_MODELS
     std::string ensure_tag = model_tag;
-    if (!this->downloader.is_model_downloaded(ensure_tag)) {
-        this->downloader.pull_model(ensure_tag, this->modelscope);
+    switch (this->downloader.is_model_downloaded(ensure_tag)) {
+        case ModelDownloader::ModelStatus::Ready:
+            break;
+        case ModelDownloader::ModelStatus::Outdated:
+        case ModelDownloader::ModelStatus::Missing:
+            this->downloader.pull_model(ensure_tag, this->modelscope);
+            break;
+        case ModelDownloader::ModelStatus::Incompatible:
+            header_print("ERROR", "EmbeddingGemma is incompatible with this version of FastFlowLM, skipping... ");
+            return;
     }
     auto [embedding_model_tag, auto_embedding_engine] = get_auto_embedding_model(ensure_tag, &this->npu_device_inst);
     this->auto_embedding_engine = std::move(auto_embedding_engine);

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -433,6 +433,7 @@ void RestHandler::ensure_asr_model_loaded(const std::string& model_tag) {
             break;
         case ModelDownloader::ModelStatus::Incompatible:
             header_print("ERROR", "Whisper is incompatible with this version of FastFlowLM, skipping... ");
+            this->asr = false;
             return;
     }
     this->whisper_engine = std::make_unique<Whisper>(&this->npu_device_inst);
@@ -464,6 +465,7 @@ void RestHandler::ensure_embed_model_loaded(const std::string& model_tag) {
             break;
         case ModelDownloader::ModelStatus::Incompatible:
             header_print("ERROR", "EmbeddingGemma is incompatible with this version of FastFlowLM, skipping... ");
+            this->embed = false;
             return;
     }
     auto [embedding_model_tag, auto_embedding_engine] = get_auto_embedding_model(ensure_tag, &this->npu_device_inst);

--- a/src/src/main.cpp
+++ b/src/src/main.cpp
@@ -645,28 +645,11 @@ int main(int argc, char* argv[]) {
             // server->stop();
         }
         else if (parsed_args.command == "pull") {
-            // Check if the model is already downloaded, if true, the model will not be downloaded
-            // Check if model is already downloaded
-            if (!parsed_args.force_redownload && downloader.is_model_downloaded(parsed_args.model_tag)) {
-                header_print("FLM", "Model is already downloaded.");
-                // Show missing files if any, this will be used to show the missing files
-                auto missing_files = downloader.get_missing_files(parsed_args.model_tag);
-                if (!missing_files.empty()) {
-                    header_print("FLM", "Missing files:");
-                    for (const auto& file : missing_files) {
-                        std::cout << "  - " << file << std::endl;
-                    }
-                } else {
-                    header_print("FLM", "All required files are present.");
-                }
-            } else {
-                // Download the model, this will be used to download the model
                 bool success = downloader.pull_model(parsed_args.model_tag, parsed_args.modelscope, parsed_args.force_redownload);
                 if (!success) {
                     header_print("ERROR", "Failed to pull model: " + parsed_args.model_tag);
-                    return 1;
+                    return 1; 
                 }
-            }
         }
         else if (parsed_args.command == "remove") {
             // Remove the model, this will be used to remove the model
@@ -688,10 +671,11 @@ int main(int argc, char* argv[]) {
                 for (const auto& model : models["models"]) {
                     // Fast path: `list` only needs presence + compatibility,
                     // so skip HF metadata fetch and per-file hash verification.
-                    bool is_present = downloader.is_model_downloaded(model["name"].get<std::string>(), /*parsed_args.sub_process_mode*/true, /*fast_check=*/true);
+                    ModelDownloader::ModelStatus status = downloader.is_model_downloaded(model["name"].get<std::string>(), /*parsed_args.sub_process_mode*/true, /*fast_check=*/true);
+                    bool is_present = (status == ModelDownloader::ModelStatus::Ready);
                     if ((parsed_args.list_filter == "installed") == is_present || parsed_args.list_filter == "all") {
                         nlohmann::json model_entry = model;
-                        model_entry["installed"] = is_present ? true : false;
+                        model_entry["installed"] = is_present;
                         output_json["models"].push_back(model_entry);
                     }
                 }
@@ -703,11 +687,17 @@ int main(int argc, char* argv[]) {
                 bool any_model_listed = false;
                 for (const auto& model : models["models"]) {
                     // Fast path: skip HF metadata fetch and per-file hash verification.
-                    bool is_present = downloader.is_model_downloaded(model["name"].get<std::string>(), parsed_args.sub_process_mode, /*fast_check=*/true);
+                    ModelDownloader::ModelStatus status = downloader.is_model_downloaded(model["name"].get<std::string>(), parsed_args.sub_process_mode, /*fast_check=*/true);
+                    bool is_present = (status == ModelDownloader::ModelStatus::Ready);
                     if ((parsed_args.list_filter == "installed") == is_present || parsed_args.list_filter == "all") {
                         std::cout << "  - " << model["name"].get<std::string>();
                         if (!parsed_args.sub_process_mode) {
-                            std::cout << (is_present ? " ✅" : " ⏬");
+                            switch (status) {
+                                case ModelDownloader::ModelStatus::Ready:        std::cout << " ✅"; break;
+                                case ModelDownloader::ModelStatus::Missing:      std::cout << " ⏬"; break;
+                                case ModelDownloader::ModelStatus::Outdated:     std::cout << " ⚠️"; break;
+                                case ModelDownloader::ModelStatus::Incompatible: std::cout << " ⚠️"; break;
+                            }
                         }
                         std::cout << std::endl;
                         any_model_listed = true;


### PR DESCRIPTION
## Summary

Replaces the old boolean "is model downloaded?" check with a `ModelStatus` enum (`Ready`, `Missing`, `Outdated`, `Incompatible`), so the CLI and server can tell the difference between:

- a model that's fully present and compatible,
- one that's missing entirely,
- one that's present but too old for the current FLM version (needs re-pulling), and
- one that's newer than the current FLM version (needs an FLM upgrade, not a re-pull).

Included fixes

- `is_model_downloaded()` now correctly reports `Missing` (not `Ready`) when `config.json` is present but other model files are still missing.

- Server no longer crashes when a cached Whisper/embedding model is `Incompatible: this->asr/this->embed` are now reset to `false` so request handlers fall back to their existing "no model loaded" response instead of dereferencing a null engine pointer.