### PR TITLE
docs: replace installer terms with MIT license

### DIFF
--- a/src/inno/terms.rtf
+++ b/src/inno/terms.rtf
@@ -1,54 +1,12 @@
 {\rtf1\ansi\ansicpg1252\deff0\nouicompat{\fonttbl{\f0\fswiss\fcharset0 Segoe UI;}}
 \viewkind4\uc1\pard\sa200\sl276\slmult1\f0\fs18
-TERMS OF USE\par
+MIT License\par
 \par
-By clicking "I Agree" or by installing or using this software, you agree to all terms below. If you do not agree, do not install or use this software.\par
+Copyright (c) 2025 FastFlowLM\par
 \par
-LICENSE\par
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\par
 \par
-This software contains two types of components:\par
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\par
 \par
-Open-source components (such as the command-line interface and orchestration scripts) are licensed under the MIT License. You may use, modify, and distribute these freely, including for commercial purposes.\par
-\par
-Proprietary binary components (such as NPU-accelerated kernels) are NOT open source. These binaries are protected by one or more pending patents and are distributed under separate terms.\par
-\par
-You may use the Binaries for commercial purposes without a separate commercial license until your company\'92s annual gross revenue exceeds USD 10 million.\par
-Once your company\'92s annual revenue exceeds this threshold, you must obtain a commercial license from the Licensor to continue use.\par
-To request a commercial license, contact: info@fastflowlm.com\par
-\par
-If you wish to run your own model with FastFlowLM, we offer optimization services. Please contact us at info@fastflowlm.com for details.\par
-\par
-PATENT PENDING\par
-\par
-The proprietary components of this software are subject to one or more pending U.S. and international patent applications. Unauthorized use may result in liability.\par
-\par
-RESTRICTIONS\par
-\par
-You may NOT:\par
-a. Use the Binaries for any commercial purpose unless you meet the conditions in Section 4 and, if required, have obtained a commercial license.\par
-b. Modify, reverse-engineer, disassemble, or decompile the Binaries.\par
-c. Redistribute, publish, upload, or otherwise make the Binaries available to any third party, whether for commercial or non-commercial purposes, without prior written permission from the Licensor.\par
-d. Remove or obscure any copyright, trademark, or patent notices contained in or on the Binaries.\par
-\par
-NO WARRANTY\par
-\par
-This software is provided "AS IS" without any warranties, express or implied. We do not guarantee performance, reliability, or suitability for any purpose.\par
-\par
-You assume all risks associated with using this software. We are not liable for any damages, losses, or data issues arising from its use.\par
-\par
-TERMINATION\par
-\par
-This license will terminate automatically if you violate any of these terms. Upon termination, you must delete all copies of the software and cease use immediately.\par
-\par
-EXPORT COMPLIANCE\par
-\par
-You agree to comply with all applicable U.S. and international export control laws and regulations. You may not use or export this software in violation of any such laws.\par
-\par
-GOVERNING LAW\par
-\par
-This agreement is governed by the laws of the State of Delaware, United States. Any legal disputes must be resolved in a court located in Delaware.\par
-\par
----\par
-\par
-By clicking "I Agree," you confirm that you have read, understood, and accepted all of the above terms.\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\par
 }

--- a/src/inno/terms.txt
+++ b/src/inno/terms.txt
@@ -1,51 +1,21 @@
-TERMS OF USE
+MIT License
 
-By clicking "I Agree" or by installing or using this software, you agree to all terms below. If you do not agree, do not install or use this software.
+Copyright (c) 2025 FastFlowLM
 
-LICENSE
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This software contains two types of components:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Open-source components (such as the command-line interface and orchestration scripts) are licensed under the MIT License. You may use, modify, and distribute these freely, including for commercial purposes.,
-
-Proprietary binary components (such as NPU-accelerated kernels) are NOT open source. These binaries are protected by one or more pending patents and are distributed under separate terms.,
-
-You may use the Binaries for commercial purposes without a separate commercial license until your company’s annual gross revenue exceeds USD 10 million.
-Once your company’s annual revenue exceeds this threshold, you must obtain a commercial license from the Licensor to continue use.
-To request a commercial license, contact: info@fastflowlm.com
-
-If you wish to run your own model with FastFlowLM, we offer optimization services. Please contact us at info@fastflowlm.com for details.
-
-PATENT PENDING
-
-The proprietary components of this software are subject to one or more pending U.S. and international patent applications. Unauthorized use may result in liability.
-
-RESTRICTIONS
-
-You may NOT:
-a. Use the Binaries for any commercial purpose unless you meet the conditions in Section 4 and, if required, have obtained a commercial license.
-b. Modify, reverse-engineer, disassemble, or decompile the Binaries.
-c. Redistribute, publish, upload, or otherwise make the Binaries available to any third party, whether for commercial or non-commercial purposes, without prior written permission from the Licensor.
-d. Remove or obscure any copyright, trademark, or patent notices contained in or on the Binaries.
-
-NO WARRANTY
-
-This software is provided "AS IS" without any warranties, express or implied. We do not guarantee performance, reliability, or suitability for any purpose.
-
-You assume all risks associated with using this software. We are not liable for any damages, losses, or data issues arising from its use.
-
-TERMINATION
-
-This license will terminate automatically if you violate any of these terms. Upon termination, you must delete all copies of the software and cease use immediately.
-
-EXPORT COMPLIANCE
-
-You agree to comply with all applicable U.S. and international export control laws and regulations. You may not use or export this software in violation of any such laws.
-
-GOVERNING LAW
-
-This agreement is governed by the laws of the State of Delaware, United States. Any legal disputes must be resolved in a court located in Delaware.
-
----
-
-By clicking "I Agree," you confirm that you have read, understood, and accepted all of the above terms.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The installer license files still carried the superseded binary terms (USD 10M revenue threshold, patent-pending clause, redistribution and reverse-engineering restrictions, Delaware governing law). The README has stated since 85c0b7d4 that the NPU kernels are free for any use, including commercial use.

Replace both with the MIT text from LICENSE_RUNTIME.txt:
- terms.txt (Inno LicenseFile) is now identical to LICENSE_RUNTIME.txt
- terms.rtf (WixUILicenseRtf) carries the same text, keeping its existing RTF header and font styling

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
