### PR TITLE
docs: add project history page

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ flm serve llama3.2:1b
 
 ## 📰 In the News
 
-- 07/17/2026 🎉 FLM is now part of AMD **[news](https://www.amd.com/en/blogs/2026/fastflowlm-joins-amd-to-advance-ai-inference.html)**.
+- 07/17/2026 🎉 FLM is now part of AMD **[news](https://www.amd.com/en/blogs/2026/fastflowlm-joins-amd-to-advance-ai-inference.html)**. Read **[our story](./flm_history.md)** — from a 2025 university project to AMD.
 
 - 03/11/2026 🎉 FLM now supports Linux 🐧 ! To get started, check out the **[quick start guide](https://fastflowlm.com/docs/install_lin/)** or the **[Lemonade Server docs](https://lemonade-server.ai/flm_npu_linux.html)**, and watch the **[short video](https://www.youtube.com/watch?v=tXRchP3sKA8)** for a quick walkthrough of FLM on Linux via Lemonade 🍋.
 

--- a/flm_history.md
+++ b/flm_history.md
@@ -1,0 +1,71 @@
+# 📜 History of FastFlowLM (FLM)
+
+From a 2025 university research project to the NPU-first runtime for AMD Ryzen™ AI — now part of AMD.
+
+---
+
+## 🎓 2025 — A University Project
+
+Modern AMD Ryzen™ AI laptops all shipped with a capable, power-efficient NPU. Almost nobody could run an LLM on it. The silicon sat idle while inference ran on the CPU and GPU.
+
+FastFlowLM started as an **NSF-funded university research project** aimed squarely at that gap. The bet: closing it required co-designing kernels around the NPU's dataflow architecture from the ground up — not porting an existing runtime onto it.
+
+What began as federally funded lab work became **FastFlowLM, Inc.** in 2025, and the runtime was released publicly as open source that June.
+
+### Founders
+
+- **[Tao Wei](https://www.clemson.edu/cecas/departments/ece/faculty_staff/faculty/twei.html)** — Professor of ECE, Clemson University; directs the NEXT Lab (domain-specific accelerators, reconfigurable computing, applied ML). Leads FLM kernel strategy.
+- **[Ken Qing Yang](https://web.uri.edu/ecbe/meet/qing-ken-yang/)** — Distinguished Engineering Professor, University of Rhode Island. 30+ years in computer architecture; serial entrepreneur behind four deep-tech startups, including VeloBit (acquired by Western Digital) and [DapuStor](https://en.dapustor.com/).
+- **[Zhenyu (Alfred) Xu](https://scholar.google.com/citations?hl=en&user=iuIZeGYAAAAJ)** — Research Assistant Professor, Clemson University. Accelerator design and on-device AI inference, with hardware–software co-optimization across FPGA, CGRA, and AI accelerators.
+
+The wider founding team brought four PhDs and three B.S. graduates in Electrical and Computer Engineering.
+
+---
+
+## 🚀 2025–2026 — Building in the Open
+
+First public commit landed **June 16, 2025**; **v0.1.0** nine days later. The design principle was borrowed from tools developers already liked — *"Think Ollama, but deeply optimized for NPUs."* Install in seconds, `flm run <model>`, done.
+
+FLM was **MIT-licensed and open source from the start**, built on **[IRON](https://github.com/amd/iron)**, the open-source NPU compiler technology developed and released by AMD's **Research and Advanced Development (RAD) Group**. That open foundation, plus close alignment with **[Lemonade](https://lemonade-server.ai/)** (AMD's open-source inference initiative), drove adoption across developers and ISVs.
+
+| Date | Milestone |
+|---|---|
+| **Jun 16, 2025** | First public commit |
+| **Jun 25, 2025** | v0.1.0 — first tagged release |
+| **Oct 1, 2025** | Integrated into AMD's Lemonade Server 🍋 |
+| **Mar 11, 2026** | Linux support launches 🐧 |
+| **Jul 17, 2026** | **FastFlowLM joins AMD** 🎉 |
+| **Aug 7, 2026** | Repo moves to the **ROCm** organization |
+| **Aug 10, 2026** | **v1.0.0** 🎊 |
+
+Over that span: 60+ releases, 1,500+ commits, ~38 contributors. The runtime grew past text to **Vision, Audio, Embedding, and MoE** models with context up to **256k tokens** — in a **17 MB** package.
+
+---
+
+## 🤝 July 17, 2026 — Joining AMD
+
+The FastFlowLM team [joined AMD](https://www.amd.com/en/blogs/2026/fastflowlm-joins-amd-to-advance-ai-inference.html), joining the **AMD Artificial Intelligence Group** to accelerate the client and workstation AI software stack and Day-0 enablement of new models. AMD called it:
+
+> "another key step in our strategy to advance AI performance and efficiency across the stack."
+
+And on the open ecosystem:
+
+> "We remain committed to investing in this open ecosystem, and we're thrilled to build the future of on-device AI together."
+
+Joining AMD did not close the project. FLM stays **open source under the MIT license**, and its NPU kernels remain **free for any use, including commercial use**.
+
+---
+
+## 🏠 August 2026 — Home in ROCm
+
+On **August 7, 2026** the repo moved from `FastFlowLM/FastFlowLM` to **[ROCm/FastFlowLM](https://github.com/ROCm/FastFlowLM)**, alongside AMD's open-source ROCm organization. **v1.0.0** shipped three days later.
+
+The mission is unchanged: **turn idle NPU silicon into instant, private, power-efficient AI.**
+
+---
+
+## 📚 References
+
+- **[AMD Blog — FastFlowLM joins AMD to advance AI inference](https://www.amd.com/en/blogs/2026/fastflowlm-joins-amd-to-advance-ai-inference.html)** *(primary source)*
+- [Phoronix — FastFlowLM Developers Join AMD](https://www.phoronix.com/news/FastFlowLM-Joins-AMD)
+- [fastflowlm.com](https://fastflowlm.com/) · [Docs](https://fastflowlm.com/docs) · [Team](https://fastflowlm.com/team/)


### PR DESCRIPTION
Add flm_history.md covering FLM's arc: an NSF-funded university research project targeting idle Ryzen AI NPU silicon, the founding team and their backgrounds, development in the open from June 2025, the team joining AMD in June 2026, and the move to the ROCm org.

Sourced primarily from the AMD announcement blog, with milestone dates taken from this repo's git history and release tags.

Linked from the "In the News" section of the README.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
