### PR TITLE
docs: remove stale OOC note from Gemma 4 benchmark

### DIFF
--- a/docs/docs/benchmarks/gemma4_results.md
+++ b/docs/docs/benchmarks/gemma4_results.md
@@ -35,9 +35,6 @@ AMD Ryzen™ AI 7 350 (Kraken Point) with 32 GB DRAM; performance is comparable 
 | **Gemma 4 E2B**  | NPU (FLM)    | 22.6	| 21.7	| 20.0	| 17.5	| 14.1 |	10.1 |
 | **Gemma 4 E4B**  | NPU (FLM)    | 12.6 | 12.3 | 11.6 | 10.6 | 9.0 | 6.8 |
 
-> OOC: Out Of Context Length  
-> Each LLM has a maximum supported context window. For example, the gemma4:1b model supports up to 32k tokens.
-
 ---
 
 ### 🚀 Prefill Speed (TPS, or Tokens per Second, with different prompt lengths)


### PR DESCRIPTION
It looks like it was copied from gemma3 which had 64k/128k OOC, but gemma4 table doesn't include that.

## Motivation

Cleanup docs from unrelated residue.

## Technical Details

docs-only

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
