### PR TITLE
fix: add bounds check to prevent OOB read in _shared_insert

### DIFF
--- a/src/common/AutoModel/automodel.cpp
+++ b/src/common/AutoModel/automodel.cpp
@@ -163,9 +163,9 @@ bool AutoModel::_shared_insert(chat_meta_info_t& meta_info, std::vector<int>& to
     const size_t idx = this->token_history.size();
     size_t skip_count = 0;
     for (size_t i = 0; i < idx; i++) {
-        if (tokens[i] == this->token_history[i]) {
+        if (i < tokens.size() && tokens[i] == this->token_history[i]) {
             skip_count++;
-        } 
+        }
         else {
             break;
         }


### PR DESCRIPTION
## Summary
- Guard the prefix-match loop in `AutoModel::_shared_insert` with a bounds check on `tokens.size()` before indexing, preventing an out-of-bounds read when `tokens` is shorter than `token_history`.

